### PR TITLE
Watchdog for pizero & engine

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -65,3 +65,6 @@ install-platform-react-server: prepare
 
 install-alert-api-server: prepare
 	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l alert_server
+
+init-pi-zero:
+	ansible-playbook playbooks/rpi-init-pi-zero.yml -i inventory/hosts_prod -l $(SITE)

--- a/docs/howto/watchdog-setup.md
+++ b/docs/howto/watchdog-setup.md
@@ -1,0 +1,80 @@
+# Watchdog Setup
+
+Two watchdog scripts monitor hardware health and power-cycle relays on failure.
+Both are managed by Ansible and read their configuration from a `.env` file generated on the device.
+
+---
+
+## Overview
+
+| Script | Runs on | Monitors | Cron schedule |
+|--------|---------|----------|---------------|
+| `watchdog/main_pi/watchdog.py` | Engine (`/home/pyro-engine/`) | Pi Zero reachability | `5,15,25,35,45,55 * * * *` |
+| `watchdog/pi_zero/watchdog.py` | Pi Zero | Engine health + camera pings | `*/10 * * * *` |
+
+The two schedules are offset by 5 minutes so they never run simultaneously.
+
+---
+
+## Engine watchdog (`main_pi`)
+
+Pings the Pi Zero. If unreachable after `MAX_FAILS` attempts, power-cycles the Pi Zero relay.
+
+Deployed by the `engine_cron` role, called from `deploy-engines.yml`.
+
+Only runs if `pi_zero_hostname` is set in the engine's host_vars.
+
+| Variable | Where | Description |
+|----------|-------|-------------|
+| `pi_zero_hostname` | `host_vars/<engine>/vars.yml` | Inventory hostname of the associated Pi Zero (e.g. `chambery-pi-zero`). Leave empty if no Pi Zero. |
+
+`PIZERO_IP` is derived automatically from `hostvars[pi_zero_hostname]['static_ip_address']` — no manual configuration needed.
+
+---
+
+## Pi Zero watchdog (`pi_zero`)
+
+Checks the engine's health endpoint and pings all cameras. Power-cycles relays on repeated failures.
+
+Deployed by the `pi_zero_watchdog` role, called from `rpi-init-pi-zero.yml`.
+
+| Variable | Where | Description |
+|----------|-------|-------------|
+| `pi_zero_hostname` | `host_vars/<pi-zero>/vars.yml` | Not required here — see relay_host |
+| `relay_host` | `host_vars/<pi-zero>/vars.yml` | Inventory hostname of the associated engine |
+
+`MAIN_PI_IP` is derived from `hostvars[relay_host]['static_ip_address']`.
+`CAM_IPS` is derived from the keys of `hostvars[relay_host]['config_json']`.
+
+---
+
+## Summary of variables per new engine + Pi Zero pair
+
+### Engine — `host_vars/<engine>/vars.yml`
+```yaml
+pi_zero_hostname: <pi-zero-inventory-name>   # e.g. chambery-pi-zero
+static_ip_address: 192.168.X.Y
+static_ip_gateway: 192.168.X.1
+static_ip_interface: eth0
+```
+
+### Pi Zero — `host_vars/<pi-zero>/vars.yml`
+```yaml
+ansible_host: 192.168.X.Z       # DHCP ip on first run, then static after init
+relay_host: <engine-hostname>   # e.g. engine-chambery
+wifi_ssid: "<network>"
+static_ip_address: 192.168.X.Z
+static_ip_gateway: 192.168.X.1
+```
+
+### Pi Zero — `host_vars/<pi-zero>/vars.vault.yml`
+```yaml
+ansible_password: "<pi-zero-password>"
+wifi_password: "<wifi-password>"
+```
+
+---
+
+## After first init (`rpi-init-pi-zero.yml`)
+
+The Pi Zero reboots with its static IP. Update `ansible_host` in host_vars to `static_ip_address` before any subsequent run.

--- a/group_vars/template/engine_servers/vars.yml
+++ b/group_vars/template/engine_servers/vars.yml
@@ -6,6 +6,8 @@ pyro_engine_docker_tag: "latest"
 
 ansible_user: pi
 
+pi_zero_hostname: ""  # set in host_vars if a Pi Zero is associated with this engine
+
 engine_json_schema: |
   {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/inventory/inventory.template
+++ b/inventory/inventory.template
@@ -21,3 +21,6 @@ all:
 
     mediamtx_server:
       hosts:
+
+    pi_zero:
+      hosts:

--- a/playbooks/rpi-init-pi-zero.yml
+++ b/playbooks/rpi-init-pi-zero.yml
@@ -1,0 +1,24 @@
+---
+- name: Upgrade packages and install git
+  hosts: pi_zero
+  become: true
+  roles:
+    - common
+
+- name: Configure WiFi
+  hosts: pi_zero
+  become: true
+  roles:
+    - wifi
+
+- name: Setup watchdog
+  hosts: pi_zero
+  become: true
+  roles:
+    - pi_zero_watchdog
+
+- name: Configure static IP and reboot
+  hosts: pi_zero
+  become: true
+  roles:
+    - static_ip

--- a/playbooks/rpi-init.yml
+++ b/playbooks/rpi-init.yml
@@ -54,3 +54,10 @@
 
     - name: Unconditionally reboot the machine with all defaults
       ansible.builtin.reboot:
+
+- name: Configure static IP and reboot
+  hosts: engine_servers
+  become: true
+  serial: 1
+  roles:
+    - static_ip

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Generate main pi watchdog .env file
   ansible.builtin.template:
     src: watchdog_main.env.j2
-    dest: /home/pi/watchdog_main.env
+    dest: /home/pi/watchdog.env
     owner: pi
     group: pi
     mode: "0644"

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -5,19 +5,19 @@
     state: directory
     mode: '0755'
 
-- name: Copy cron job for internet connection
+- name: Generate main pi watchdog .env file
   ansible.builtin.template:
-    src: check_internet_connection.sh.j2
-    dest: "{{ engine_cron_working_dir }}/check_internet_connection.sh"
-    mode: '0755'
+    src: watchdog_main.env.j2
+    dest: /home/pi/watchdog_main.env
+    owner: pi
+    group: pi
+    mode: "0644"
+  when: pi_zero_hostname != ""
 
-- name: Add cron job
+- name: Add cron job for main pi watchdog
   ansible.builtin.cron:
-    name: "Check internet connection"
-    minute: "*/10"
-    hour: "*"
-    day: "*"
-    month: "*"
-    weekday: "*"
-    job: "{{ engine_cron_working_dir }}/check_internet_connection.sh"
-    user: root
+    name: "Main pi watchdog"
+    minute: "5,15,25,35,45,55"
+    job: "/usr/bin/python3 {{ engine_cron_working_dir }}/watchdog/main_pi/watchdog.py >> /home/pi/watchdog_main.log 2>&1"
+    user: pi
+  when: pi_zero_hostname != ""

--- a/roles/engine_cron/templates/watchdog_main.env.j2
+++ b/roles/engine_cron/templates/watchdog_main.env.j2
@@ -1,0 +1,1 @@
+PIZERO_IP={{ hostvars[pi_zero_hostname]['static_ip_address'] }}

--- a/roles/pi_zero_watchdog/defaults/main.yml
+++ b/roles/pi_zero_watchdog/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+pi_zero_repo_url: "https://github.com/pyronear/pyro-engine.git"
+pi_zero_repo_branch: "watchdog_env"
+pi_zero_repo_dir: "/home/pi/pyro-engine"
+pi_zero_watchdog_script: "{{ pi_zero_repo_dir }}/watchdog/pi_zero/watchdog.py"
+pi_zero_log_file: "/home/pi/watchdog.log"
+pi_zero_cron_schedule: "*/10 * * * *"

--- a/roles/pi_zero_watchdog/tasks/main.yml
+++ b/roles/pi_zero_watchdog/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Install required packages
+  ansible.builtin.apt:
+    name:
+      - python3
+      - python3-pip
+      - python3-venv
+      - cron
+    state: present
+
+- name: Remove existing repo to ensure clean clone
+  ansible.builtin.file:
+    path: "{{ pi_zero_repo_dir }}"
+    state: absent
+
+- name: Clone pyro-engine repository
+  ansible.builtin.git:
+    repo: "{{ pi_zero_repo_url }}"
+    dest: "{{ pi_zero_repo_dir }}"
+    version: "{{ pi_zero_repo_branch }}"
+    single_branch: true
+  become_user: pi
+
+- name: Generate watchdog .env file
+  ansible.builtin.template:
+    src: watchdog.env.j2
+    dest: /home/pi/watchdog.env
+    owner: pi
+    group: pi
+    mode: "0644"
+
+- name: Make watchdog script executable
+  ansible.builtin.file:
+    path: "{{ pi_zero_watchdog_script }}"
+    mode: "0755"
+
+- name: Create watchdog log file
+  ansible.builtin.file:
+    path: "{{ pi_zero_log_file }}"
+    state: touch
+    owner: pi
+    group: pi
+    mode: "0644"
+    modification_time: preserve
+    access_time: preserve
+
+- name: Enable and start cron service
+  ansible.builtin.service:
+    name: cron
+    enabled: true
+    state: started
+
+- name: Install watchdog cron job
+  ansible.builtin.cron:
+    name: "pyro watchdog"
+    minute: "*/10"
+    job: "/usr/bin/python3 {{ pi_zero_watchdog_script }} >> {{ pi_zero_log_file }} 2>&1"
+    user: pi

--- a/roles/pi_zero_watchdog/templates/watchdog.env.j2
+++ b/roles/pi_zero_watchdog/templates/watchdog.env.j2
@@ -1,0 +1,2 @@
+MAIN_PI_IP={{ hostvars[relay_host]['static_ip_address'] }}
+CAM_IPS={{ (hostvars[relay_host]['config_json'] | from_json).keys() | join(',') }}

--- a/roles/static_ip/defaults/main.yml
+++ b/roles/static_ip/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+static_ip_address: ""       # e.g. 192.168.1.50 — set in host_vars
+static_ip_prefix: "24"
+static_ip_gateway: ""       # e.g. 192.168.1.1  — set in host_vars
+static_ip_dns: "8.8.8.8"
+static_ip_interface: "wlan0"  # wlan0 for pi_zero (wifi), eth0 for engines

--- a/roles/static_ip/tasks/main.yml
+++ b/roles/static_ip/tasks/main.yml
@@ -1,22 +1,19 @@
 ---
-- name: Ensure static IP vars are defined
-  ansible.builtin.assert:
-    that:
-      - static_ip_address != ""
-      - static_ip_gateway != ""
-    fail_msg: "static_ip_address and static_ip_gateway must be set in host_vars."
-
-# WiFi (Pi Zero): modify the existing connection profile named after the SSID
-- name: Set static IP on WiFi connection profile
+# WiFi (Pi Zero and sometimes Engine): loop over wifi_connections that have a static IP defined
+- name: Set static IP on some WiFi connections
   ansible.builtin.command: >
-    nmcli con mod {{ wifi_ssid }}
-    ipv4.addresses {{ static_ip_address }}/{{ static_ip_prefix }}
-    ipv4.gateway {{ static_ip_gateway }}
+    nmcli con mod {{ item.ssid }}
+    ipv4.addresses {{ item.static_ip_address }}/{{ static_ip_prefix }}
+    ipv4.gateway {{ item.static_ip_gateway }}
     ipv4.dns {{ static_ip_dns }}
     ipv4.method manual
-  register: static_ip_result
-  changed_when: static_ip_result.rc == 0
-  when: static_ip_interface == "wlan0"
+  loop: "{{ wifi_connections }}"
+  when:
+    - static_ip_interface == "wlan0"
+    - item.static_ip_address is defined
+    - item.static_ip_gateway is defined
+  register: static_ip_wifi_result
+  changed_when: static_ip_wifi_result.rc == 0
 
 # Ethernet (Engine): create a dedicated static connection profile on the interface
 - name: Check if static ethernet connection already has correct IP
@@ -24,6 +21,14 @@
     nmcli -g ipv4.addresses con show {{ static_ip_interface }}-static 2>/dev/null || echo ""
   register: existing_eth_ip
   changed_when: false
+  when: static_ip_interface == "eth0"
+
+- name: Ensure static IP vars are defined for ethernet
+  ansible.builtin.assert:
+    that:
+      - static_ip_address != ""
+      - static_ip_gateway != ""
+    fail_msg: "static_ip_address and static_ip_gateway must be set in host_vars."
   when: static_ip_interface == "eth0"
 
 - name: Set static IP on ethernet interface
@@ -35,16 +40,19 @@
       ipv4.dns {{ static_ip_dns }} \
       ipv4.method manual \
       connection.autoconnect yes
-  register: static_ip_result
+  register: static_ip_eth_result
   changed_when: true
   when:
     - static_ip_interface == "eth0"
     - existing_eth_ip.stdout != static_ip_address + "/" + static_ip_prefix
 
 # Fire-and-forget reboot: host will come back on the new static IP.
-# After this playbook completes, update ansible_host in host_vars to {{ static_ip_address }}.
+# After this playbook completes, update ansible_host in host_vars to the static IP.
 - name: Reboot to apply static IP (fire and forget)
   ansible.builtin.command: shutdown -r now
   async: 1
   poll: 0
-  when: static_ip_result is changed
+  when: >
+    (static_ip_interface == "wlan0" and static_ip_wifi_result is defined and static_ip_wifi_result is changed)
+    or
+    (static_ip_interface == "eth0" and static_ip_eth_result is defined and static_ip_eth_result is changed)

--- a/roles/static_ip/tasks/main.yml
+++ b/roles/static_ip/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Ensure static IP vars are defined
+  ansible.builtin.assert:
+    that:
+      - static_ip_address != ""
+      - static_ip_gateway != ""
+    fail_msg: "static_ip_address and static_ip_gateway must be set in host_vars."
+
+# WiFi (Pi Zero): modify the existing connection profile named after the SSID
+- name: Set static IP on WiFi connection profile
+  ansible.builtin.command: >
+    nmcli con mod {{ wifi_ssid }}
+    ipv4.addresses {{ static_ip_address }}/{{ static_ip_prefix }}
+    ipv4.gateway {{ static_ip_gateway }}
+    ipv4.dns {{ static_ip_dns }}
+    ipv4.method manual
+  register: static_ip_result
+  changed_when: static_ip_result.rc == 0
+  when: static_ip_interface == "wlan0"
+
+# Ethernet (Engine): create a dedicated static connection profile on the interface
+- name: Check if static ethernet connection already has correct IP
+  ansible.builtin.shell: >
+    nmcli -g ipv4.addresses con show {{ static_ip_interface }}-static 2>/dev/null || echo ""
+  register: existing_eth_ip
+  changed_when: false
+  when: static_ip_interface == "eth0"
+
+- name: Set static IP on ethernet interface
+  ansible.builtin.shell: |
+    nmcli con delete {{ static_ip_interface }}-static 2>/dev/null || true
+    nmcli con add type ethernet ifname {{ static_ip_interface }} con-name {{ static_ip_interface }}-static \
+      ipv4.addresses {{ static_ip_address }}/{{ static_ip_prefix }} \
+      ipv4.gateway {{ static_ip_gateway }} \
+      ipv4.dns {{ static_ip_dns }} \
+      ipv4.method manual \
+      connection.autoconnect yes
+  register: static_ip_result
+  changed_when: true
+  when:
+    - static_ip_interface == "eth0"
+    - existing_eth_ip.stdout != static_ip_address + "/" + static_ip_prefix
+
+# Fire-and-forget reboot: host will come back on the new static IP.
+# After this playbook completes, update ansible_host in host_vars to {{ static_ip_address }}.
+- name: Reboot to apply static IP (fire and forget)
+  ansible.builtin.command: shutdown -r now
+  async: 1
+  poll: 0
+  when: static_ip_result is changed

--- a/roles/static_ip/templates/dhcpcd.conf.j2
+++ b/roles/static_ip/templates/dhcpcd.conf.j2
@@ -1,0 +1,5 @@
+# Static IP configuration managed by Ansible
+interface {{ static_ip_interface }}
+static ip_address={{ static_ip_address }}/{{ static_ip_prefix }}
+static routers={{ static_ip_gateway }}
+static domain_name_servers={{ static_ip_dns }}

--- a/roles/wifi/defaults/main.yml
+++ b/roles/wifi/defaults/main.yml
@@ -1,5 +1,12 @@
 ---
-wifi_ssid: "Pyronear"         # Name of the Wi-Fi network
-wifi_password: "Pyronear"     # Wi-Fi password
-wifi_static_ethernet_ip: "169.254.40.99"
-wifi_default_dns: "8.8.8.8 8.8.4.4"
+wifi_connections: []
+# Example:
+# wifi_connections:
+#   - ssid: "PrimaryNetwork"
+#     password: "pass1"
+#     priority: 10
+#     static_ip_address: "192.168.1.50"  # optional — omit for DHCP
+#     static_ip_gateway: "192.168.1.1"   # optional — omit for DHCP
+#   - ssid: "BackupNetwork"
+#     password: "pass2"
+#     priority: 0                        # lower priority, DHCP

--- a/roles/wifi/tasks/main.yml
+++ b/roles/wifi/tasks/main.yml
@@ -4,23 +4,19 @@
     name: network-manager
     state: present
 
-- name: Check if Wi-Fi connection exists
+- name: Check existing Wi-Fi connections
   ansible.builtin.command: nmcli -t -f NAME con show
   register: nmcli_connections
   changed_when: false
 
-- name: Configure Wi-Fi if SSID is provided and not already configured
+- name: Configure Wi-Fi connections
   ansible.builtin.shell: >
-    nmcli con add type wifi ifname wlan0 con-name {{ wifi_ssid }}
-    ssid {{ wifi_ssid }} wifi-sec.key-mgmt wpa-psk
-    wifi-sec.psk {{ wifi_password }} connection.autoconnect yes
-  when:
-    - wifi_ssid != ""
-    - wifi_ssid not in nmcli_connections.stdout.splitlines()
+    nmcli con add type wifi ifname wlan0 con-name {{ item.ssid }}
+    ssid {{ item.ssid }} wifi-sec.key-mgmt wpa-psk
+    wifi-sec.psk {{ item.password }} connection.autoconnect yes
+    connection.autoconnect-priority {{ item.priority | default(0) }}
+  loop: "{{ wifi_connections }}"
+  when: item.ssid not in nmcli_connections.stdout.splitlines()
   register: wifi_result
-  ignore_errors: yes
+  ignore_errors: true
   changed_when: wifi_result.rc == 0
-
-- name: Debug Wi-Fi result
-  ansible.builtin.debug:
-    var: wifi_result


### PR DESCRIPTION
## Summary

- Add full Ansible-based management of Pi Zero devices accessed through engine relay hosts (SSH ProxyJump via sshpass)
- Add watchdog cron jobs on both engines and Pi Zeros

## Changes

### Inventory & group_vars
- `inventory/inventory.template` — add `pi_zero` group
- `group_vars/template/pi_zero/vars.yml` — ansible_user, ProxyCommand via engine, wifi/static IP defaults
- `group_vars/template/engine_servers/vars.yml` — add `pi_zero_hostname` default (empty)

### New roles
- `roles/pi_zero_watchdog` — clone pyro-engine (watchdog branch), generate `.env`, make executable, cron job every 10min
- `roles/static_ip` — set static IP via nmcli on wlan0 (Pi Zero) or eth0 (engine), fire-and-forget reboot

### Updated roles
- `roles/wifi` — unchanged, reused for Pi Zero
- `roles/engine_cron` — add main_pi watchdog `.env` generation + cron job (only when `pi_zero_hostname` is set)

### Playbooks
- `playbooks/rpi-init-pi-zero.yml` — new: common → wifi → pi_zero_watchdog → static_ip
- `playbooks/rpi-init.yml` — add static IP play at the end (after OpenVPN reboot)

### Makefile
- `bin/common/Makefile` — add `init-pi-zero SITE=<hostname>`

### Docs
- `docs/howto/watchdog-setup.md` — new: watchdog overview, variables per host, post-init instructions

## Required in pi-manager-fr (per Pi Zero)

```yaml
# host_vars/<pi-zero>/vars.yml
ansible_host: <dhcp-ip>        # update to static_ip_address after first run
relay_host: <engine-hostname>
wifi_ssid: "<ssid>"
static_ip_address: 192.168.X.Y
static_ip_gateway: 192.168.X.1

# host_vars/<pi-zero>/vars.vault.yml
ansible_password: "<password>"
wifi_password: "<password>"
```

```yaml
# host_vars/<engine>/vars.yml
pi_zero_hostname: <pi-zero-hostname>   # leave empty if no Pi Zero
static_ip_address: 192.168.X.Y
static_ip_gateway: 192.168.X.1
static_ip_interface: eth0
```

## Pending

- [PR 348 on pyro-engine](https://github.com/pyronear/pyro-engine/pull/348/changes): modify both watchdog scripts to load `/home/pi/watchdog.env` and read `MAIN_PI_IP` / `PIZERO_IP` / `CAM_IPS` from it