### PR TITLE
  Install galaxy roles in docker image    

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,9 @@ COPY ./init_script /ansible/init_script
 COPY ./inventory /ansible/inventory
 COPY ./playbooks /ansible/playbooks
 COPY ./roles /ansible/roles
+COPY ./requirements.yml /ansible/requirements.yml
+RUN ansible-galaxy role install -r /ansible/requirements.yml -p /ansible/galaxy_roles \
+ && ansible-galaxy collection install -r /ansible/requirements.yml
 COPY ./docker/docker-entrypoint.sh /ansible/docker-entrypoint.sh
 
 ENTRYPOINT [ "/ansible/docker-entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,15 +15,16 @@ RUN mkdir /ansible && mkdir -p /ansible/.ssh
 
 WORKDIR /ansible
 
+COPY ./requirements.yml /ansible/requirements.yml
+RUN ansible-galaxy role install -r /ansible/requirements.yml -p /ansible/galaxy_roles \
+ && ansible-galaxy collection install -r /ansible/requirements.yml
+
 COPY ./group_vars /ansible/group_vars
 COPY ./hooks /ansible/hooks
 COPY ./init_script /ansible/init_script
 COPY ./inventory /ansible/inventory
 COPY ./playbooks /ansible/playbooks
 COPY ./roles /ansible/roles
-COPY ./requirements.yml /ansible/requirements.yml
-RUN ansible-galaxy role install -r /ansible/requirements.yml -p /ansible/galaxy_roles \
- && ansible-galaxy collection install -r /ansible/requirements.yml
 COPY ./docker/docker-entrypoint.sh /ansible/docker-entrypoint.sh
 
 ENTRYPOINT [ "/ansible/docker-entrypoint.sh" ]

--- a/docker/ansible.cfg
+++ b/docker/ansible.cfg
@@ -3,4 +3,4 @@ remote_user = ubuntu
 ssh_private_key_file=/root/.ssh/id_rsa
 host_key_checking = False
 vault_password_file=/root/.vault_passwrd
-roles_path=/ansible/roles
+roles_path=/ansible/roles:/ansible/galaxy_roles


### PR DESCRIPTION
                                                                                                                                                                                                  
  - make ansible-up → make install-alert-api-server failed with the role 'pyronear.openvpn' was not found because the dockerized flow never installed the Galaxy roles from requirements.yml.      
  - Rebuilding alone didn't help: docker-compose.yml bind-mounts ./roles:/ansible/roles, which shadows anything written to /ansible/roles in the image.
  - Fix: install Galaxy roles to /ansible/galaxy_roles (a path not touched by any volume mount) during image build, and add that directory to roles_path in docker/ansible.cfg. Checked-in roles in
   ./roles still take precedence; only the Galaxy-only ones (pyronear.openvpn, infothrill.rpi_boot_config) are picked up from the new path. Collections go to the default                          
  /root/.ansible/collections and are found automatically.  
  
  
  
```
  Nothing to prepare
ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l alert_server
ERROR! the role 'pyronear.openvpn' was not found in /ansible/playbooks/roles:/ansible/roles:/ansible/playbooks

The error appears to be in '/ansible/playbooks/deploy-servers.yml': line 29, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  roles:
    - pyronear.openvpn
      ^ here
make: *** [/ansible/MakefileCommon:67: install-alert-api-server] Error 1
sh-5.2# 

```