### PR TITLE
Rebuild pyro-ansible image on make ansible-up

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -9,7 +9,7 @@ semaphore-stop:
 	@docker compose stop
 
 ansible-up:
-	@docker compose up -d pyro-ansible
+	@docker compose up -d --build pyro-ansible
 	@docker exec -it pyro-ansible sh
 
 ansible-stop:


### PR DESCRIPTION
 - Add --build to the docker compose up call in ansible-up so the image is always rebuilt and stays in sync with the Dockerfile.                                                                  
  - We hit an issue on #24  because of this: Compose silently reused the cached image and skipped Dockerfile changes, so a fix that was actually in the repo looked un-applied until the
   image was manually rebuilt. Safer to always build.                                                                                                                                              
  - Rebuilds stay fast thanks to Docker's layer cache when nothing changed