### PR TITLE
optional stage

### DIFF
--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -12,7 +12,7 @@
     owner: pi
     group: pi
     mode: "0644"
-  when: pi_zero_hostname != ""
+  when: pi_zero_hostname | default("") | length > 0
 
 - name: Add cron job for main pi watchdog
   ansible.builtin.cron:
@@ -20,4 +20,4 @@
     minute: "5,15,25,35,45,55"
     job: "/usr/bin/python3 {{ engine_cron_working_dir }}/watchdog/main_pi/watchdog.py >> /home/pi/watchdog_main.log 2>&1"
     user: pi
-  when: pi_zero_hostname != ""
+  when: pi_zero_hostname | default("") | length > 0


### PR DESCRIPTION
 ## Summary
  - Make the main pi watchdog (.env + cron) skip cleanly when `pi_zero_hostname` is undefined or empty, instead of failing with `'pi_zero_hostname' is undefined` on engines that have no paired Pi
   Zero (e.g. `st-peray`).                                                                                                                                                                         
  - Rebuild the `pyro-ansible` image on `make ansible-up` so Dockerfile changes are picked up without a manual rebuild.