### PR TITLE
Added deploy-all-engines make target

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -39,6 +39,9 @@ init-one-engine:
 deploy-one-engine:
 	ansible-playbook playbooks/deploy-engines.yml -i inventory/hosts_prod -l $(SITE)
 
+deploy-all-engines:
+	ansible-playbook playbooks/deploy-engines.yml -i inventory/hosts_prod -l engine_servers
+
 down: prepare
 	@SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/down-engines.yml -i inventory/hosts_prod -l engine_servers
 

--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -21,18 +21,6 @@ ping: prepare
 check-engines: prepare
 	@SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/check-engine.yml -i inventory/hosts_prod -l engine_servers
 
-init-engine: prepare
-	@bash -c 'set -a; source init_script/.env; set +a;SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/rpi-init.yml -i inventory/hosts_prod -l engine_servers'
-
-init-engine-filtered: prepare
-	@bash -c 'set -a; source init_script/.env; set +a;SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/rpi-init.yml -i inventory/hosts_prod -l $(LIMIT)'
-
-install-engines: prepare
-	@bash -c 'set -a; source init_script/.env; set +a;SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/deploy-engines.yml -i inventory/hosts_prod -l engine_servers'
-
-install-engines-filtered: prepare
-	@bash -c 'set -a; source init_script/.env; set +a;SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/deploy-engines.yml -i inventory/hosts_prod -l $(LIMIT)'
-
 init-one-engine:
 	ansible-playbook playbooks/rpi-init.yml -i inventory/hosts_prod -l $(SITE),mediamtx_server
 


### PR DESCRIPTION
Add deploy-all-engines make target to run deploy-engines.yml against the entire engine_servers group via native ansible-playbook (no git-check wrapper, no prepare), mirroring the style of    
  deploy-one-engine but fleet-wide