### PR TITLE
Fix wifi update pwd

### DIFF
--- a/roles/pi_zero_watchdog/defaults/main.yml
+++ b/roles/pi_zero_watchdog/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 pi_zero_repo_url: "https://github.com/pyronear/pyro-engine.git"
-pi_zero_repo_branch: "watchdog_env"
+pi_zero_repo_branch: "develop"
 pi_zero_repo_dir: "/home/pi/pyro-engine"
 pi_zero_watchdog_script: "{{ pi_zero_repo_dir }}/watchdog/pi_zero/watchdog.py"
 pi_zero_log_file: "/home/pi/watchdog.log"

--- a/roles/wifi/tasks/main.yml
+++ b/roles/wifi/tasks/main.yml
@@ -4,19 +4,19 @@
     name: network-manager
     state: present
 
-- name: Check existing Wi-Fi connections
-  ansible.builtin.command: nmcli -t -f NAME con show
-  register: nmcli_connections
-  changed_when: false
-
 - name: Configure Wi-Fi connections
-  ansible.builtin.shell: >
-    nmcli con add type wifi ifname wlan0 con-name {{ item.ssid }}
-    ssid {{ item.ssid }} wifi-sec.key-mgmt wpa-psk
-    wifi-sec.psk {{ item.password }} connection.autoconnect yes
-    connection.autoconnect-priority {{ item.priority | default(0) }}
+  ansible.builtin.shell: |
+    if nmcli con show "{{ item.ssid }}" &>/dev/null; then
+      nmcli con mod "{{ item.ssid }}" \
+        wifi-sec.psk "{{ item.password }}" \
+        connection.autoconnect-priority {{ item.priority | default(0) }} \
+        connection.autoconnect-retries 0
+    else
+      nmcli con add type wifi ifname wlan0 con-name "{{ item.ssid }}" \
+        ssid "{{ item.ssid }}" wifi-sec.key-mgmt wpa-psk \
+        wifi-sec.psk "{{ item.password }}" connection.autoconnect yes \
+        connection.autoconnect-priority {{ item.priority | default(0) }} \
+        connection.autoconnect-retries 0
+    fi
   loop: "{{ wifi_connections }}"
-  when: item.ssid not in nmcli_connections.stdout.splitlines()
-  register: wifi_result
-  ignore_errors: true
-  changed_when: wifi_result.rc == 0
+  changed_when: true


### PR DESCRIPTION
The Wi-Fi configuration was not being updated when the password changed. This PR ensures that the password is updated when necessary.

It also updates the configuration to point to the default branch used for the Pi Zero.