### PR TITLE
perf(alert-api): run uvicorn with 2 workers

### DIFF
--- a/roles/alert_api/templates/docker-compose.yml.j2
+++ b/roles/alert_api/templates/docker-compose.yml.j2
@@ -70,7 +70,7 @@ services:
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=pyroresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=5050"
-    command: "sh -c 'python app/db.py && uvicorn app.main:app --reload --host 0.0.0.0 --port 5050 --proxy-headers --use-colors'"
+    command: "sh -c 'python app/db.py && uvicorn app.main:app --workers 2 --host 0.0.0.0 --port 5050 --proxy-headers --use-colors'"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:5050/status"]
       interval: 10s


### PR DESCRIPTION
- Replace `--reload` with `--workers 2` in the alert-api uvicorn command.
- Targets the 2 vCPU production server; matches workers to CPU cores per async-Uvicorn guidance (FastAPI + asyncpg is fully async).
- `--reload` was a dev-only flag and incompatible with multi-worker mode.