### PR TITLE
Bump platform-react to v0.3.1 and alert-api to 1.0.1

### DIFF
--- a/roles/alert_api/defaults/main.yml
+++ b/roles/alert_api/defaults/main.yml
@@ -1,6 +1,6 @@
 alert_api_working_dir: /home/alert_api
 alert_api_working_dir_traefik: /home/traefik
-alert_api_docker_version: v1.0.1
+alert_api_docker_version: 1.0.1
 
 alert_api_proxy_url:
 alert_api_s3_proxy_url:

--- a/roles/alert_api/defaults/main.yml
+++ b/roles/alert_api/defaults/main.yml
@@ -1,6 +1,6 @@
 alert_api_working_dir: /home/alert_api
 alert_api_working_dir_traefik: /home/traefik
-alert_api_docker_version: latest
+alert_api_docker_version: v1.0.1
 
 alert_api_proxy_url:
 alert_api_s3_proxy_url:

--- a/roles/platform_react/defaults/main.yml
+++ b/roles/platform_react/defaults/main.yml
@@ -1,7 +1,7 @@
 platform_react_working_dir_react: /home/pyro_platform_react
 platform_react_working_dir_traefik: /home/traefik
 platform_react_docker_image: pyronear/pyro-platform-react
-platform_react_docker_version: 0.3.0
+platform_react_docker_version: v0.3.1
 
 platform_react_url_frontend: TO_CHANGE
 platform_react_url_backend: TO_CHANGE


### PR DESCRIPTION
## Summary
- `platform_react_docker_version`: `0.3.0` → `v0.3.1`
- `alert_api_docker_version`: `latest` → `1.0.1`

## Note
The `pyro-platform-react` repo tags releases with a `v` prefix (`v0.3.1`), unlike `alert-api` and others (`1.0.1`). We should align `pyro-platform-react` to drop the `v` so all images follow the same convention.