### PR TITLE
Add postgres backup script for alert-api DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ id_rsa
 .env
 .vault_passwrd*
 *.iml
+*.dump

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ id_rsa
 .env
 .vault_passwrd*
 *.iml
-*.dump
+backups/

--- a/bin/backup_postgres.sh
+++ b/bin/backup_postgres.sh
@@ -43,24 +43,46 @@ fi
 
 echo "Target: ${SSH_USER}@${SERVER_HOST}"
 
+# Quote remote-side values to survive spaces / shell metacharacters.
+Q_ENV_FILE=$(printf '%q' "${ENV_FILE}")
+Q_CONTAINER=$(printf '%q' "${CONTAINER}")
+
 # ====== READ DB CREDS FROM SERVER ======
 echo "Reading DB config from ${ENV_FILE}..."
-PGUSER=$(ssh "${SSH_USER}@${SERVER_HOST}" "grep '^POSTGRES_USER=' ${ENV_FILE} | cut -d= -f2-")
-DB=$(ssh "${SSH_USER}@${SERVER_HOST}" "grep '^POSTGRES_DB=' ${ENV_FILE} | cut -d= -f2-")
+read_env_var() {
+  local key="$1"
+  ssh "${SSH_USER}@${SERVER_HOST}" \
+    "set -o pipefail; grep -E ^${key}= ${Q_ENV_FILE} | head -n1 | cut -d= -f2-"
+}
+
+PGUSER=$(read_env_var POSTGRES_USER)
+DB=$(read_env_var POSTGRES_DB)
+
+if [ -z "${PGUSER}" ] || [ -z "${DB}" ]; then
+  echo "ERROR: POSTGRES_USER or POSTGRES_DB missing in ${ENV_FILE}" >&2
+  exit 1
+fi
+
+Q_PGUSER=$(printf '%q' "${PGUSER}")
+Q_DB=$(printf '%q' "${DB}")
 
 OUTPUT_FILE="${DB}_${DATE}.dump"
+TMP_FILE="${OUTPUT_FILE}.tmp.$$"
+trap 'rm -f "${TMP_FILE}"' EXIT INT TERM
 
 # ====== BACKUP ======
 echo "Starting backup of ${DB} (user=${PGUSER}) → ${OUTPUT_FILE}..."
 ssh "${SSH_USER}@${SERVER_HOST}" \
-  "sudo docker exec ${CONTAINER} pg_dump -U ${PGUSER} -d ${DB} -Fc" \
-  > "${OUTPUT_FILE}"
+  "sudo docker exec ${Q_CONTAINER} pg_dump -U ${Q_PGUSER} -d ${Q_DB} -Fc" \
+  > "${TMP_FILE}"
 
 # ====== VERIFY ======
-SIZE=$(stat -f%z "${OUTPUT_FILE}" 2>/dev/null || stat -c%s "${OUTPUT_FILE}")
+SIZE=$(stat -f%z "${TMP_FILE}" 2>/dev/null || stat -c%s "${TMP_FILE}")
 if [ "${SIZE}" -lt 1024 ]; then
   echo "ERROR: backup file too small (${SIZE} bytes)" >&2
   exit 1
 fi
 
+mv "${TMP_FILE}" "${OUTPUT_FILE}"
+trap - EXIT INT TERM
 echo "Backup OK: ${OUTPUT_FILE} (${SIZE} bytes)"

--- a/bin/backup_postgres.sh
+++ b/bin/backup_postgres.sh
@@ -53,7 +53,7 @@ OUTPUT_FILE="${DB}_${DATE}.dump"
 # ====== BACKUP ======
 echo "Starting backup of ${DB} (user=${PGUSER}) → ${OUTPUT_FILE}..."
 ssh "${SSH_USER}@${SERVER_HOST}" \
-  "docker exec ${CONTAINER} pg_dump -U ${PGUSER} -d ${DB} -Fc" \
+  "sudo docker exec ${CONTAINER} pg_dump -U ${PGUSER} -d ${DB} -Fc" \
   > "${OUTPUT_FILE}"
 
 # ====== VERIFY ======

--- a/bin/backup_postgres.sh
+++ b/bin/backup_postgres.sh
@@ -7,6 +7,7 @@ GROUP="${GROUP:-alert_server}"
 SSH_USER="${SSH_USER:-ubuntu}"
 CONTAINER="${CONTAINER:-alert-api-db-1}"
 ENV_FILE="${ENV_FILE:-/home/alert_api/.env}"
+OUTPUT_DIR="${OUTPUT_DIR:-backups}"
 DATE=$(date +%Y%m%d_%H%M)
 
 # Run from repo root regardless of CWD
@@ -66,7 +67,8 @@ fi
 Q_PGUSER=$(printf '%q' "${PGUSER}")
 Q_DB=$(printf '%q' "${DB}")
 
-OUTPUT_FILE="${DB}_${DATE}.dump"
+mkdir -p "${OUTPUT_DIR}"
+OUTPUT_FILE="${OUTPUT_DIR}/${DB}_${DATE}.dump"
 TMP_FILE="${OUTPUT_FILE}.tmp.$$"
 trap 'rm -f "${TMP_FILE}"' EXIT INT TERM
 

--- a/bin/backup_postgres.sh
+++ b/bin/backup_postgres.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# ====== CONFIG ======
+INVENTORY="${INVENTORY:-inventory/hosts_prod}"
+GROUP="${GROUP:-alert_server}"
+SSH_USER="${SSH_USER:-ubuntu}"
+CONTAINER="${CONTAINER:-alert-api-db-1}"
+ENV_FILE="${ENV_FILE:-/home/alert_api/.env}"
+DATE=$(date +%Y%m%d_%H%M)
+
+# ====== READ HOST FROM ANSIBLE INVENTORY ======
+if [ ! -f "${INVENTORY}" ]; then
+  echo "ERROR: inventory '${INVENTORY}' not found — run 'make prepare' first" >&2
+  exit 1
+fi
+
+SERVER_HOST=$(ansible-inventory -i "${INVENTORY}" --list | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+host = d['${GROUP}']['hosts'][0]
+print(d['_meta']['hostvars'][host]['ansible_host'])
+")
+
+echo "Target: ${SSH_USER}@${SERVER_HOST}"
+
+# ====== READ DB CREDS FROM SERVER ======
+echo "Reading DB config from ${ENV_FILE}..."
+PGUSER=$(ssh "${SSH_USER}@${SERVER_HOST}" "grep '^POSTGRES_USER=' ${ENV_FILE} | cut -d= -f2-")
+DB=$(ssh "${SSH_USER}@${SERVER_HOST}" "grep '^POSTGRES_DB=' ${ENV_FILE} | cut -d= -f2-")
+
+OUTPUT_FILE="${DB}_${DATE}.dump"
+
+# ====== BACKUP ======
+echo "Starting backup of ${DB} (user=${PGUSER}) → ${OUTPUT_FILE}..."
+ssh "${SSH_USER}@${SERVER_HOST}" \
+  "docker exec ${CONTAINER} pg_dump -U ${PGUSER} -d ${DB} -Fc" \
+  > "${OUTPUT_FILE}"
+
+# ====== VERIFY ======
+SIZE=$(stat -f%z "${OUTPUT_FILE}" 2>/dev/null || stat -c%s "${OUTPUT_FILE}")
+if [ "${SIZE}" -lt 1024 ]; then
+  echo "ERROR: backup file too small (${SIZE} bytes)" >&2
+  exit 1
+fi
+
+echo "Backup OK: ${OUTPUT_FILE} (${SIZE} bytes)"

--- a/bin/backup_postgres.sh
+++ b/bin/backup_postgres.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# ====== CONFIG ======
+# ====== CONFIG (overridable via env) ======
 INVENTORY="${INVENTORY:-inventory/hosts_prod}"
 GROUP="${GROUP:-alert_server}"
 SSH_USER="${SSH_USER:-ubuntu}"
@@ -9,18 +9,37 @@ CONTAINER="${CONTAINER:-alert-api-db-1}"
 ENV_FILE="${ENV_FILE:-/home/alert_api/.env}"
 DATE=$(date +%Y%m%d_%H%M)
 
-# ====== READ HOST FROM ANSIBLE INVENTORY ======
+# Run from repo root regardless of CWD
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
 if [ ! -f "${INVENTORY}" ]; then
   echo "ERROR: inventory '${INVENTORY}' not found — run 'make prepare' first" >&2
   exit 1
 fi
 
-SERVER_HOST=$(ansible-inventory -i "${INVENTORY}" --list | python3 -c "
+# ====== RESOLVE SERVER IP FROM INVENTORY ======
+# Allow manual override; otherwise try local ansible-inventory; fall back to docker container.
+if [ -z "${SERVER_HOST:-}" ]; then
+  echo "Resolving IP for group ${GROUP} via Ansible inventory..."
+
+  if command -v ansible-inventory >/dev/null 2>&1; then
+    INV_JSON=$(ansible-inventory -i "${INVENTORY}" --list)
+  else
+    echo "  ansible-inventory not in PATH — using pyro-ansible docker container"
+    INV_JSON=$(docker compose run --rm -T pyro-ansible \
+      ansible-inventory -i "${INVENTORY}" --list 2>/dev/null)
+  fi
+
+  SERVER_HOST=$(echo "${INV_JSON}" | python3 -c "
 import json, sys
-d = json.load(sys.stdin)
+data = sys.stdin.read()
+data = data[data.find('{'):]   # strip any entrypoint pre-output
+d = json.loads(data)
 host = d['${GROUP}']['hosts'][0]
 print(d['_meta']['hostvars'][host]['ansible_host'])
 ")
+fi
 
 echo "Target: ${SSH_USER}@${SERVER_HOST}"
 


### PR DESCRIPTION
## Summary
Adds `bin/backup_postgres.sh` to dump the alert-api postgres DB to a local `backups/` directory.

- Server IP resolved from Ansible inventory (no hardcoded IP)
- DB name and user read from the remote `.env` (no hardcoded creds)
- Falls back to `pyro-ansible` docker container if `ansible-inventory` isn't on PATH
- Writes to a temp file and only renames after `pg_dump` succeeds + size check passes
- `backups/` is gitignored

## Usage
```bash
make prepare
./bin/backup_postgres.sh
```