### PR TITLE
fix: run alembic migrations on annotation backend startup

### DIFF
--- a/roles/servers/templates/docker-compose.annotator.yml.j2
+++ b/roles/servers/templates/docker-compose.annotator.yml.j2
@@ -81,7 +81,7 @@ services:
       - "traefik.http.routers.backend.tls.certresolver=pyroresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=5050"
     restart: always
-    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
+    command: "sh -c 'alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:5050/status"]
       interval: 10s

--- a/roles/servers/templates/docker-compose.annotator.yml.j2
+++ b/roles/servers/templates/docker-compose.annotator.yml.j2
@@ -81,7 +81,7 @@ services:
       - "traefik.http.routers.backend.tls.certresolver=pyroresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=5050"
     restart: always
-    command: "sh -c 'python app/db.py && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
+    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:5050/status"]
       interval: 10s


### PR DESCRIPTION
- Swap the legacy `python app/db.py` bootstrap for `alembic upgrade head` in `docker-compose.annotator.yml.j2`, matching the change in pyronear/pyro-annotator#119 — the API now manages its DB schema via Alembic.
- Use `exec uvicorn` so SIGTERM reaches the web server cleanly during deploys/restarts.