### PR TITLE
fix: parametrize annotation server hostnames

### DIFF
--- a/group_vars/template/annotation_server/vars.yml
+++ b/group_vars/template/annotation_server/vars.yml
@@ -1,2 +1,8 @@
 ---
 app_name: "annotator"
+
+# Public hostnames served by traefik on the annotation server.
+# Override per-environment in inventory (group_vars or host_vars).
+# Defaults applied in roles/servers/templates/docker-compose.annotator.yml.j2.
+annotation_api_host: "annotationapi.pyronear.org"
+annotation_app_host: "annotator.pyronear.org"

--- a/group_vars/template/annotation_server/vars.yml
+++ b/group_vars/template/annotation_server/vars.yml
@@ -3,6 +3,7 @@ app_name: "annotator"
 
 # Public hostnames served by traefik on the annotation server.
 # Override per-environment in inventory (group_vars or host_vars).
-# Defaults applied in roles/servers/templates/docker-compose.annotator.yml.j2.
+# The j2 template falls back to these same production values when the
+# variables are unset, so leaving them empty in inventory is safe.
 annotation_api_host: "annotationapi.pyronear.org"
 annotation_app_host: "annotator.pyronear.org"

--- a/roles/servers/templates/docker-compose.annotator.yml.j2
+++ b/roles/servers/templates/docker-compose.annotator.yml.j2
@@ -32,7 +32,7 @@ services:
         - "--certificatesresolvers.default.acme.storage=/acme.json"
       restart: always
       healthcheck:
-        test: "wget --no-verbose --tries=1 --spider  https://annotationdev.pyronear.org/status || exit 1"
+        test: "wget --no-verbose --tries=1 --spider  https://{{ annotation_api_host | default('annotationapi.pyronear.org') }}/status || exit 1"
         interval: 20s
         timeout: 20s
         retries: 10
@@ -76,7 +76,7 @@ services:
       - ACCESS_TOKEN_EXPIRE_HOURS=24
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`annotationdev.pyronear.org`)"
+      - "traefik.http.routers.backend.rule=Host(`{{ annotation_api_host | default('annotationapi.pyronear.org') }}`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=pyroresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=5050"
@@ -97,7 +97,7 @@ services:
       - 80
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.frontend.rule=Host(`annotator.pyronear.org`)"
+      - "traefik.http.routers.frontend.rule=Host(`{{ annotation_app_host | default('annotator.pyronear.org') }}`)"
       - "traefik.http.routers.frontend.entrypoints=websecure"
       - "traefik.http.routers.frontend.tls.certresolver=pyroresolver"
       - "traefik.http.services.frontend.loadbalancer.server.port=80"

--- a/roles/servers/templates/docker-compose.annotator.yml.j2
+++ b/roles/servers/templates/docker-compose.annotator.yml.j2
@@ -1,7 +1,7 @@
 name: pyronear
 services:
   traefik:
-      image: traefik:v2.9.6
+      image: traefik:v2.11
       container_name: traefik
       ports:
         # http(s) traffic

--- a/roles/servers/templates/docker-compose.annotator.yml.j2
+++ b/roles/servers/templates/docker-compose.annotator.yml.j2
@@ -32,7 +32,7 @@ services:
         - "--certificatesresolvers.default.acme.storage=/acme.json"
       restart: always
       healthcheck:
-        test: "wget --no-verbose --tries=1 --spider  https://{{ annotation_api_host | default('annotationapi.pyronear.org') }}/status || exit 1"
+        test: "wget --no-verbose --tries=1 --spider  https://{{ annotation_api_host | default('annotationapi.pyronear.org', true) }}/status || exit 1"
         interval: 20s
         timeout: 20s
         retries: 10
@@ -76,7 +76,7 @@ services:
       - ACCESS_TOKEN_EXPIRE_HOURS=24
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`{{ annotation_api_host | default('annotationapi.pyronear.org') }}`)"
+      - "traefik.http.routers.backend.rule=Host(`{{ annotation_api_host | default('annotationapi.pyronear.org', true) }}`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=pyroresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=5050"
@@ -97,7 +97,7 @@ services:
       - 80
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.frontend.rule=Host(`{{ annotation_app_host | default('annotator.pyronear.org') }}`)"
+      - "traefik.http.routers.frontend.rule=Host(`{{ annotation_app_host | default('annotator.pyronear.org', true) }}`)"
       - "traefik.http.routers.frontend.entrypoints=websecure"
       - "traefik.http.routers.frontend.tls.certresolver=pyroresolver"
       - "traefik.http.services.frontend.loadbalancer.server.port=80"


### PR DESCRIPTION
- Replace hardcoded `annotationdev.pyronear.org` / `annotator.pyronear.org` host rules with `annotation_api_host` / `annotation_app_host` variables, so each environment can override its public hostnames in inventory without forking the template.
- Defaults match the current production VM (`annotationapi.pyronear.org` for the API, `annotator.pyronear.org` for the frontend) so existing clients keep working after redeploy.
- Use `default(value, true)` so an empty inventory string still falls back to the production default.