### PR TITLE
Configure Risk API for alert-api deployment

### DIFF
--- a/roles/alert_api/defaults/main.yml
+++ b/roles/alert_api/defaults/main.yml
@@ -20,6 +20,10 @@ alert_api_server_name:
 alert_api_sentry_dsn:
 alert_api_telegram_token:
 alert_api_posthog_key:
+alert_api_risk_api_url:
+alert_api_risk_api_login:
+alert_api_risk_api_pwd:
+alert_api_risk_refresh_hour_utc: 4
 
 cert_resolver_mail:
 cert_resolver_url:

--- a/roles/alert_api/defaults/main.yml
+++ b/roles/alert_api/defaults/main.yml
@@ -1,6 +1,6 @@
 alert_api_working_dir: /home/alert_api
 alert_api_working_dir_traefik: /home/traefik
-alert_api_docker_version: 1.0.1
+alert_api_docker_version: 1.0.2
 
 alert_api_proxy_url:
 alert_api_s3_proxy_url:

--- a/roles/alert_api/templates/.env.j2
+++ b/roles/alert_api/templates/.env.j2
@@ -21,3 +21,8 @@ SERVER_NAME='{{ alert_api_server_name }}'
 TELEGRAM_TOKEN={{ alert_api_telegram_token }}
 POSTHOG_KEY='{{ alert_api_posthog_key }}'
 PLATFORM_URL={{ alert_api_platform_url }}
+
+RISK_API_URL='{{ alert_api_risk_api_url }}'
+RISK_API_LOGIN='{{ alert_api_risk_api_login }}'
+RISK_API_PWD='{{ alert_api_risk_api_pwd }}'
+RISK_REFRESH_HOUR_UTC={{ alert_api_risk_refresh_hour_utc }}

--- a/roles/alert_api/templates/docker-compose.yml.j2
+++ b/roles/alert_api/templates/docker-compose.yml.j2
@@ -64,13 +64,17 @@ services:
       - S3_PROXY_URL=${S3_PROXY_URL}
       - SERVER_NAME=${SERVER_NAME}
       - PLATFORM_URL=${PLATFORM_URL:-https://platform.pyronear.org}
+      - RISK_API_URL=${RISK_API_URL}
+      - RISK_API_LOGIN=${RISK_API_LOGIN}
+      - RISK_API_PWD=${RISK_API_PWD}
+      - RISK_REFRESH_HOUR_UTC=${RISK_REFRESH_HOUR_UTC:-4}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=Host(`{{ alert_api_proxy_url }}`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=pyroresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=5050"
-    command: "sh -c 'python app/db.py && uvicorn app.main:app --workers 2 --host 0.0.0.0 --port 5050 --proxy-headers --use-colors'"
+    command: "sh -c 'alembic upgrade head && python app/db.py && uvicorn app.main:app --workers 2 --host 0.0.0.0 --port 5050 --proxy-headers --use-colors'"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:5050/status"]
       interval: 10s


### PR DESCRIPTION
Follow-up to pyronear/pyro-api#583.

This updates the alert-api deployment template to:
- pass Risk API environment variables to the backend container
- render Risk API settings in the generated `.env`
- run Alembic migrations before starting the API

Required inventory variables:
- `alert_api_risk_api_url`
- `alert_api_risk_api_login`
- `alert_api_risk_api_pwd`
- `alert_api_risk_refresh_hour_utc`