### PR TITLE
fix: pin cryptography==46.0.7 to fix ansible-galaxy SIGILL on ARM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,7 @@ RUN apt update ; \
   apt -y install make; \
   apt -y install vim; \
   apt -y install nano; \
-  pip install netaddr; \
-  pip install ansible==10.3.0; \
+  pip install netaddr ansible==10.3.0 cryptography==46.0.7; \
   ln -sf /bin/bash /bin/sh;
 
 RUN mkdir /ansible && mkdir -p /ansible/.ssh


### PR DESCRIPTION
## Summary
- `make ansible-up` was failing on ARM with `ansible-galaxy` exiting 132 (SIGILL) during the `pyro-ansible` image build.
- Root cause: `cryptography` 47.x/48.x ARM wheels crash on import — see [pyca/cryptography#14733](https://github.com/pyca/cryptography/issues/14733). 48.0.0 is the current latest (released 2026-05-04) and there's no patched 48.0.1 / 49.x yet.
- Pin `cryptography==46.0.7` (latest 46.x) alongside `ansible==10.3.0` until upstream ships a fix.

