### PR TITLE
fix(make): drop wrapper from install-annotation-server

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -49,7 +49,7 @@ update-mediamtx-conf: prepare
 	@SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/update-mediamtx.yml -i inventory/hosts_prod -l mediamtx_server
 
 install-annotation-server: prepare
-	@SECOND_REPO=$(REPO_PATH) ./bin/pyro-ansible playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l annotation_server
+	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l annotation_server
 
 install-platform-react-server: prepare
 	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l platform_react_server


### PR DESCRIPTION
## Why
`make install-annotation-server` fails inside the docker container (`make ansible-up`) with:

    /bin/sh: line 1: ./bin/pyro-ansible: No such file or directory

The git-cleanliness wrapper `./bin/pyro-ansible` is not available there because `./bin` is not mounted into the container.

## What
Match the pattern already used by `install-platform-react-server` and `install-alert-api-server` and call `ansible-playbook` directly. One line, no other targets touched.

Works in both native and docker contexts. Native users who want the host-side git checks can still invoke `./bin/pyro-ansible` manually.