### PR TITLE
Add SSH key management role & fix engine init steps for reliability

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -59,3 +59,6 @@ install-alert-api-server: prepare
 
 init-pi-zero:
 	ansible-playbook playbooks/rpi-init-pi-zero.yml -i inventory/hosts_prod -l $(SITE)
+
+sync-ssh-keys:
+	ansible-playbook playbooks/sync-ssh-keys.yml -i inventory/hosts_prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ${REPO_PATH}/inventory/group_vars:/ansible/inventory/group_vars
       - ${REPO_PATH}/host_vars:/ansible/inventory/host_vars
       - ${REPO_PATH}/inventory:/ansible/inventory
+      - ${REPO_PATH}/ssh_keys:/ansible/ssh_keys:ro
     stdin_open: true
     tty: true
     command: "sh"

--- a/init_script/cameras.csv
+++ b/init_script/cameras.csv
@@ -1,1 +1,1 @@
-name,angle_of_view,elevation,lat,lon,is_trustable
+name,angle_of_view,elevation,lat,lon,is_trustable,n_poses

--- a/init_script/create_cameras.py
+++ b/init_script/create_cameras.py
@@ -3,30 +3,50 @@ import pandas as pd
 from common import get_token, api_request, get_organization_id
 from dotenv import load_dotenv
 
-# Charger les variables d'environnement depuis le fichier .env
 load_dotenv(override=True)
 
 api_url = os.getenv("API_URL")
 superuser_login = os.getenv("SUPERADMIN_LOGIN")
 superuser_pwd = os.getenv("SUPERADMIN_PWD")
-
 organization_name = os.getenv("organization_name")
-
-print(api_url)
 
 superuser_auth = {
     "Authorization": f"Bearer {get_token(api_url, superuser_login, superuser_pwd)}",
     "Content-Type": "application/json",
 }
 
-cameras = pd.read_csv(f"cameras.csv")
-cameras = cameras.fillna("")
-
+cameras_csv = pd.read_csv("cameras.csv")
+cameras_csv = cameras_csv.fillna(0)
 
 organization_id = get_organization_id(api_url, superuser_auth, organization_name)
 
-# Créer les caméras
-for camera in cameras.itertuples(index=False):
+# Fetch existing cameras to avoid duplicates
+existing = api_request("get", f"{api_url}/api/v1/cameras/?include_non_trustable=true", superuser_auth)
+existing_names = {c["name"] for c in existing if c["organization_id"] == organization_id}
+
+
+def compute_azimuths(cam_index: int, total_ptz_cams: int, n_poses: int) -> list:
+    """Evenly distribute azimuths across all PTZ cameras at the site."""
+    total_positions = total_ptz_cams * n_poses
+    step = 360 / total_positions
+    start = cam_index * n_poses
+    return [round(step * (start + j)) % 360 for j in range(n_poses)]
+
+
+# Count PTZ cameras (n_poses > 0) for azimuth distribution
+ptz_rows = [c for c in cameras_csv.itertuples(index=False) if int(c.n_poses) > 0]
+total_ptz = len(ptz_rows)
+
+ptz_index = 0
+for camera in cameras_csv.itertuples(index=False):
+    n_poses = int(camera.n_poses)
+
+    if camera.name in existing_names:
+        print(f"Camera '{camera.name}' already exists, skipping.")
+        if n_poses > 0:
+            ptz_index += 1
+        continue
+
     payload = {
         "organization_id": organization_id,
         "name": camera.name,
@@ -34,8 +54,22 @@ for camera in cameras.itertuples(index=False):
         "elevation": camera.elevation,
         "lat": camera.lat,
         "lon": camera.lon,
-        "is_trustable": camera.is_trustable,
+        "is_trustable": bool(camera.is_trustable),
     }
     response = api_request("post", f"{api_url}/api/v1/cameras/", superuser_auth, payload)
     camera_id = response["id"]
-    print(f"Camera '{camera.name}' créée avec succès avec l'id : '{camera_id}'.")
+    print(f"Camera '{camera.name}' created with id: {camera_id}")
+
+    if n_poses > 0:
+        azimuths = compute_azimuths(ptz_index, total_ptz, n_poses)
+        pose_ids = []
+        for patrol_id, azimuth in enumerate(azimuths):
+            pose_payload = {
+                "camera_id": camera_id,
+                "azimuth": azimuth,
+                "patrol_id": patrol_id,
+            }
+            pose_resp = api_request("post", f"{api_url}/api/v1/poses/", superuser_auth, pose_payload)
+            pose_ids.append(pose_resp["id"])
+        print(f"  -> {n_poses} poses created | pose_ids: {pose_ids} | patrol_ids: {list(range(n_poses))}")
+        ptz_index += 1

--- a/playbooks/deploy-engines.yml
+++ b/playbooks/deploy-engines.yml
@@ -13,18 +13,6 @@
   roles:
     - check_vars
 
-- name: Schedule daily reboot cron
-  hosts: engine_servers
-  become: true
-  tasks:
-    - name: Create a cronjob to restart the Raspberry Pi every day at midnight
-      ansible.builtin.cron:
-        name: "Restart Raspberry Pi"
-        minute: "0"
-        hour: "0"
-        job: "/sbin/shutdown -r now"
-        user: "root"
-
 - name: Deploy Docker Compose Engines
   hosts: engine_servers
   become: true

--- a/playbooks/rpi-init-pi-zero.yml
+++ b/playbooks/rpi-init-pi-zero.yml
@@ -4,6 +4,7 @@
   become: true
   roles:
     - common
+    - authorized_keys
 
 - name: Configure WiFi
   hosts: pi_zero

--- a/playbooks/rpi-init.yml
+++ b/playbooks/rpi-init.yml
@@ -12,6 +12,7 @@
 
   roles:
     - common
+    - authorized_keys
     - wifi
     - docker
 

--- a/playbooks/sync-ssh-keys.yml
+++ b/playbooks/sync-ssh-keys.yml
@@ -1,0 +1,6 @@
+---
+- name: Sync authorized SSH keys
+  hosts: all
+  become: true
+  roles:
+    - authorized_keys

--- a/roles/authorized_keys/defaults/main.yml
+++ b/roles/authorized_keys/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ssh_authorized_keys: []

--- a/roles/authorized_keys/tasks/main.yml
+++ b/roles/authorized_keys/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Collect public key contents
+  ansible.builtin.set_fact:
+    _ssh_pubkeys: "{{ _ssh_pubkeys | default([]) + [lookup('file', '/ansible/ssh_keys/' + item + '.pub')] }}"
+  loop: "{{ ssh_authorized_keys }}"
+
+- name: Enforce authorized keys
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user }}"
+    key: "{{ _ssh_pubkeys | join('\n') }}"
+    exclusive: true
+    state: present

--- a/roles/engine/tasks/main.yml
+++ b/roles/engine/tasks/main.yml
@@ -14,12 +14,16 @@
     name: "pyronear/pyro-engine:{{ pyro_engine_docker_tag }}"
     source: pull
     force_source: true
+  retries: 3
+  delay: 10
 
 - name: Pull pyro-camera-api image from Docker Hub
   community.docker.docker_image:
     name: "pyronear/pyro-camera-api:{{ pyro_engine_docker_tag }}"
     source: pull
     force_source: true
+  retries: 3
+  delay: 10
 
 - name: Create a directory if it does not exist
   ansible.builtin.file:
@@ -128,4 +132,3 @@
 - name: Ensure Docker Compose containers are running
   community.docker.docker_compose_v2:
     project_src: /home/{{ app_name }}/
-    wait: true

--- a/roles/engine/tasks/main.yml
+++ b/roles/engine/tasks/main.yml
@@ -14,6 +14,8 @@
     name: "pyronear/pyro-engine:{{ pyro_engine_docker_tag }}"
     source: pull
     force_source: true
+  register: pull_pyro_engine
+  until: pull_pyro_engine is not failed
   retries: 3
   delay: 10
 
@@ -22,6 +24,8 @@
     name: "pyronear/pyro-camera-api:{{ pyro_engine_docker_tag }}"
     source: pull
     force_source: true
+  register: pull_pyro_camera_api
+  until: pull_pyro_camera_api is not failed
   retries: 3
   delay: 10
 

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Create a cronjob to restart the Raspberry Pi every day at midnight
+  ansible.builtin.cron:
+    name: "Restart Raspberry Pi"
+    minute: "0"
+    hour: "0"
+    job: "/sbin/shutdown -r now"
+    user: "root"
+  when: pi_zero_hostname is not defined or pi_zero_hostname | length == 0
+
 - name: Ensure working directory exists
   ansible.builtin.file:
     path: "{{ engine_cron_working_dir }}"

--- a/roles/static_ip/tasks/main.yml
+++ b/roles/static_ip/tasks/main.yml
@@ -39,7 +39,8 @@
       ipv4.gateway {{ static_ip_gateway }} \
       ipv4.dns {{ static_ip_dns }} \
       ipv4.method manual \
-      connection.autoconnect yes
+      connection.autoconnect yes \
+      connection.autoconnect-priority 100
   register: static_ip_eth_result
   changed_when: true
   when:

--- a/roles/wifi/tasks/main.yml
+++ b/roles/wifi/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Configure Wi-Fi connections
   ansible.builtin.shell: |
-    if nmcli con show "{{ item.ssid }}" &>/dev/null; then
+    if nmcli -t -f NAME con show | grep -qF "{{ item.ssid }}"; then
       nmcli con mod "{{ item.ssid }}" \
         wifi-sec.psk "{{ item.password }}" \
         connection.autoconnect-priority {{ item.priority | default(0) }} \


### PR DESCRIPTION
## SSH key management

- New authorized_keys role: pushes keys from ssh_keys/ (inventory repo) using ansible.posix.authorized_key with exclusive: true — revocation works by removing the slug and re-running
- Mounted ${REPO_PATH}/ssh_keys into the Ansible container
- Role added to both rpi-init.yml and rpi-init-pi-zero.yml
- New make sync-ssh-keys target to push/sync keys independently

## Init fixes

- Wi-Fi check now uses exact name match
- Static ethernet gets autoconnect-priority 100
- Daily reboot cron moved into engine_cron role with pi_zero guard
 - D ocker image pulls retry on failure; compose start no longer waits

## Init script

- Added is_trustable field to camera CSV
- create_cameras.py now creates default related poses and prints resulting camera/pose IDs