### PR TITLE
feat: add temporal_server deployment for temporal-model API

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -57,6 +57,9 @@ install-platform-react-server: prepare
 install-alert-api-server: prepare
 	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l alert_server
 
+install-temporal-server: prepare
+	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l temporal_server
+
 init-pi-zero:
 	ansible-playbook playbooks/rpi-init-pi-zero.yml -i inventory/hosts_prod -l $(SITE)
 

--- a/inventory/inventory.template
+++ b/inventory/inventory.template
@@ -22,5 +22,8 @@ all:
     mediamtx_server:
       hosts:
 
+    temporal_server:
+      hosts:
+
     pi_zero:
       hosts:

--- a/playbooks/deploy-servers.yml
+++ b/playbooks/deploy-servers.yml
@@ -16,7 +16,7 @@
     - check_vars
 
 - name: Upgrade, install git and docker
-  hosts: alert_server:platform_py_server:platform_react_server:openvpn:mediamtx_server
+  hosts: alert_server:platform_py_server:platform_react_server:openvpn:mediamtx_server:temporal_server
   become: true
   roles:
     - common
@@ -72,5 +72,13 @@
   become: true
   roles:
     - role: alert_api
+      tags:
+        - app
+
+- name: Deploy service temporal_api
+  hosts: temporal_server
+  become: true
+  roles:
+    - role: temporal_api
       tags:
         - app

--- a/roles/temporal_api/defaults/main.yml
+++ b/roles/temporal_api/defaults/main.yml
@@ -1,0 +1,20 @@
+temporal_api_working_dir: /home/temporal_api
+temporal_api_working_dir_traefik: /home/traefik
+temporal_api_docker_image: pyronear/temporal-model-api
+temporal_api_docker_version: 0.3.0
+
+# Public domain served by Traefik (set in the sister repo, e.g. temporalmodelapi.pyronear.org)
+temporal_api_url:
+
+# Shared bearer token guarding POST /predict
+temporal_api_token:
+
+# S3 backend (reuses the existing prod S3)
+temporal_api_s3_bucket:
+temporal_api_s3_region:
+temporal_api_s3_endpoint_url:
+temporal_api_s3_access_key:
+temporal_api_s3_secret_key:
+
+cert_resolver_mail:
+cert_resolver_url:

--- a/roles/temporal_api/tasks/main.yml
+++ b/roles/temporal_api/tasks/main.yml
@@ -1,5 +1,21 @@
 ---
 
+- name: Assert required temporal_api variables are set
+  ansible.builtin.assert:
+    that:
+      - temporal_api_url | default('', true) | length > 0
+      - temporal_api_token | default('', true) | length > 0
+      - temporal_api_s3_bucket | default('', true) | length > 0
+      - temporal_api_s3_region | default('', true) | length > 0
+      - temporal_api_s3_endpoint_url | default('', true) | length > 0
+      - temporal_api_s3_access_key | default('', true) | length > 0
+      - temporal_api_s3_secret_key | default('', true) | length > 0
+    fail_msg: >-
+      Missing temporal_api configuration. Set temporal_api_url, temporal_api_token
+      and the temporal_api_s3_* vars in the sister repo before deploying. An empty
+      token would expose POST /predict unauthenticated.
+    quiet: true
+
 - name: Create a network
   community.docker.docker_network:
     name: web

--- a/roles/temporal_api/tasks/main.yml
+++ b/roles/temporal_api/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: Create a network
+  community.docker.docker_network:
+    name: web
+
+- name: Create working directories if they do not exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  with_items:
+    - "{{ temporal_api_working_dir }}"
+    - "{{ temporal_api_working_dir_traefik }}"
+    - "{{ temporal_api_working_dir_traefik }}/logs"
+
+- name: Stop all services
+  community.docker.docker_compose_v2:
+    project_src: "{{ temporal_api_working_dir }}"
+    state: absent
+  ignore_errors: true
+
+- name: Create empty acme file for traefik
+  ansible.builtin.copy:
+    content: ""
+    dest: "{{ temporal_api_working_dir_traefik }}/acme.json"
+    force: false
+    mode: 0600 # required by traefik
+
+- name: Create conf file for traefik
+  ansible.builtin.template:
+    src: traefik.toml.j2
+    dest: "{{ temporal_api_working_dir_traefik }}/traefik.toml"
+    mode: "0600"
+
+- name: Copy docker-compose.yml and .env for temporal_api
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "{{ temporal_api_working_dir }}/{{ item }}"
+    mode: "0644"
+  with_items:
+    - "docker-compose.yml"
+    - ".env"
+
+- name: Docker Compose start and verify containers are running
+  community.docker.docker_compose_v2:
+    project_src: "{{ temporal_api_working_dir }}"
+    wait: true
+    wait_timeout: 120

--- a/roles/temporal_api/tasks/main.yml
+++ b/roles/temporal_api/tasks/main.yml
@@ -5,15 +5,16 @@
     that:
       - temporal_api_url | default('', true) | length > 0
       - temporal_api_token | default('', true) | length > 0
-      - temporal_api_s3_bucket | default('', true) | length > 0
       - temporal_api_s3_region | default('', true) | length > 0
       - temporal_api_s3_endpoint_url | default('', true) | length > 0
       - temporal_api_s3_access_key | default('', true) | length > 0
       - temporal_api_s3_secret_key | default('', true) | length > 0
     fail_msg: >-
       Missing temporal_api configuration. Set temporal_api_url, temporal_api_token
-      and the temporal_api_s3_* vars in the sister repo before deploying. An empty
-      token would expose POST /predict unauthenticated.
+      and the temporal_api_s3_* credentials/endpoint vars in the sister repo before
+      deploying. An empty token would expose POST /predict unauthenticated.
+      (temporal_api_s3_bucket is optional — it is only a fallback for requests that
+      do not specify a bucket.)
     quiet: true
 
 - name: Create a network

--- a/roles/temporal_api/templates/.env.j2
+++ b/roles/temporal_api/templates/.env.j2
@@ -1,0 +1,8 @@
+# S3 credentials are read from the boto3 chain (standard AWS_* env vars)
+AWS_ACCESS_KEY_ID={{ temporal_api_s3_access_key }}
+AWS_SECRET_ACCESS_KEY={{ temporal_api_s3_secret_key }}
+
+TEMPORAL_API_TOKEN='{{ temporal_api_token }}'
+TEMPORAL_API_S3_BUCKET={{ temporal_api_s3_bucket }}
+TEMPORAL_API_S3_REGION={{ temporal_api_s3_region }}
+TEMPORAL_API_S3_ENDPOINT_URL='{{ temporal_api_s3_endpoint_url }}'

--- a/roles/temporal_api/templates/docker-compose.yml.j2
+++ b/roles/temporal_api/templates/docker-compose.yml.j2
@@ -1,0 +1,44 @@
+name: temporal-api
+
+services:
+  reverse-proxy:
+    image: traefik:v3.6.6
+    container_name: traefik
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - {{ temporal_api_working_dir_traefik }}/traefik.toml:/etc/traefik/traefik.toml
+      - {{ temporal_api_working_dir_traefik }}/acme.json:/acme.json
+      - {{ temporal_api_working_dir_traefik }}/logs:/var/log
+    restart: always
+    networks:
+      - web
+
+  backend:
+    image: {{ temporal_api_docker_image }}:{{ temporal_api_docker_version }}
+    container_name: temporal-api
+    env_file:
+      - .env
+    expose:
+      - 8000
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.temporal.rule=Host(`{{ temporal_api_url }}`)'
+      - 'traefik.http.routers.temporal.entrypoints=websecure'
+      - 'traefik.http.routers.temporal.tls.certresolver=pyroresolver'
+      - 'traefik.http.services.temporal.loadbalancer.server.port=8000'
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status == 200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+    restart: always
+    networks:
+      - web
+
+networks:
+  web:
+    external: true

--- a/roles/temporal_api/templates/docker-compose.yml.j2
+++ b/roles/temporal_api/templates/docker-compose.yml.j2
@@ -30,7 +30,7 @@ services:
       - 'traefik.http.routers.temporal.tls.certresolver=pyroresolver'
       - 'traefik.http.services.temporal.loadbalancer.server.port=8000'
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status == 200 else 1)\""]
+      test: ["CMD-SHELL", "python -c \"import urllib.request,json,sys; sys.exit(0 if json.load(urllib.request.urlopen('http://localhost:8000/health')).get('model_loaded') else 1)\""]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/roles/temporal_api/templates/traefik.toml.j2
+++ b/roles/temporal_api/templates/traefik.toml.j2
@@ -1,0 +1,39 @@
+[entryPoints]
+    [entryPoints.web]
+        address = ":80"
+        [entryPoints.web.http]
+            [entryPoints.web.http.redirections]
+                [entryPoints.web.http.redirections.entryPoint]
+                    to = "websecure"
+                    scheme = "https"
+                    permanent = true
+
+    [entryPoints.websecure]
+        address = ":443"
+            [entryPoints.websecure.http.tls]
+                certResolver = "pyroresolver"
+
+[providers]
+    [providers.docker]
+        watch = true
+        exposedByDefault = false
+        network = "web"
+
+[certificatesResolvers]
+    [certificatesResolvers.pyroresolver]
+        [certificatesResolvers.pyroresolver.acme]
+            tlschallenge = true
+            email = "{{ cert_resolver_mail }}"
+            storage = "acme.json"
+            caServer = "{{ cert_resolver_url }}"
+
+[log]
+    filePath = "/var/log/log-file.log"
+    level = "INFO"
+    format = "json"
+
+[accessLog]
+    format = "json"
+    filePath = "/var/log/access.log"
+    [accessLog.filters]
+        statusCodes = ["200", "400-404", "500-503"]


### PR DESCRIPTION
- Adds a `temporal_api` Ansible role that deploys `pyronear/temporal-model-api` (pinned tag `0.3.0`, pulled from Docker Hub) behind a self-contained Traefik with Let's Encrypt HTTPS.
- Registers a new `temporal_server` inventory group, a `deploy-servers.yml` play, and an `install-temporal-server` make target.
- Config via `TEMPORAL_API_*` env vars; reuses the existing prod S3 (credentials through the boto3 chain). Deploy asserts the token + S3 vars are set, and the healthcheck gates on the model being loaded.
