### PR TITLE
feat: wire temporal model API into alert_api deployment

### DIFF
--- a/roles/alert_api/defaults/main.yml
+++ b/roles/alert_api/defaults/main.yml
@@ -20,6 +20,9 @@ alert_api_server_name:
 alert_api_sentry_dsn:
 alert_api_telegram_token:
 alert_api_posthog_key:
+# Temporal model API — token must match temporal_api_token on the temporal server
+alert_api_temporal_api_url:
+alert_api_temporal_api_token:
 alert_api_risk_api_url:
 alert_api_risk_api_login:
 alert_api_risk_api_pwd:

--- a/roles/alert_api/templates/.env.j2
+++ b/roles/alert_api/templates/.env.j2
@@ -22,6 +22,9 @@ TELEGRAM_TOKEN={{ alert_api_telegram_token }}
 POSTHOG_KEY='{{ alert_api_posthog_key }}'
 PLATFORM_URL={{ alert_api_platform_url }}
 
+TEMPORAL_API_URL='{{ alert_api_temporal_api_url }}'
+TEMPORAL_API_TOKEN='{{ alert_api_temporal_api_token }}'
+
 RISK_API_URL='{{ alert_api_risk_api_url }}'
 RISK_API_LOGIN='{{ alert_api_risk_api_login }}'
 RISK_API_PWD='{{ alert_api_risk_api_pwd }}'

--- a/roles/alert_api/templates/docker-compose.yml.j2
+++ b/roles/alert_api/templates/docker-compose.yml.j2
@@ -68,6 +68,8 @@ services:
       - RISK_API_LOGIN=${RISK_API_LOGIN}
       - RISK_API_PWD=${RISK_API_PWD}
       - RISK_REFRESH_HOUR_UTC=${RISK_REFRESH_HOUR_UTC:-4}
+      - TEMPORAL_API_URL=${TEMPORAL_API_URL}
+      - TEMPORAL_API_TOKEN=${TEMPORAL_API_TOKEN}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=Host(`{{ alert_api_proxy_url }}`)"


### PR DESCRIPTION
- The alert API supports temporal sequence validation since 1.0.5, but the deployment never set `TEMPORAL_API_URL`/`TEMPORAL_API_TOKEN`, leaving the feature silently disabled (sequences concluded `fail_open_unavailable`).
- Adds both variables to `.env.j2`, the matching empty defaults, and the compose `environment:` passthrough — the backend service uses an explicit whitelist, so `.env` alone is not enough.
- Token must match `temporal_api_token` on the temporal server (vault). Inventory side: pyronear/pi-manager-fr PR with the `alert_server` group vars.