### PR TITLE
Shelly migration & Drive watchdog cron by explicit watchdog_type

### DIFF
--- a/roles/check_vars/tasks/main.yml
+++ b/roles/check_vars/tasks/main.yml
@@ -81,6 +81,33 @@
     - item.value is none or item.value | length == 0
   no_log: true
 
+- name: Check watchdog_type is set and valid on engines
+  ansible.builtin.assert:
+    that:
+      - watchdog_type is defined
+      - watchdog_type in ["no_watchdog", "pi_zero", "shelly"]
+    fail_msg: >-
+      'watchdog_type' must be one of: no_watchdog, pi_zero, shelly
+      (host: {{ inventory_hostname }}, got: {{ watchdog_type | default("<undefined>") }}).
+    success_msg: "watchdog_type = {{ watchdog_type }}"
+  when: inventory_hostname in groups["engine_servers"]
+
+- name: Check pi_zero_hostname is set when watchdog_type == pi_zero
+  ansible.builtin.fail:
+    msg: "'pi_zero_hostname' is required when watchdog_type == 'pi_zero' (host: {{ inventory_hostname }})."
+  when:
+    - inventory_hostname in groups["engine_servers"]
+    - watchdog_type | default("") == "pi_zero"
+    - pi_zero_hostname is not defined or pi_zero_hostname | length == 0
+
+- name: Check shelly_ip is set when watchdog_type == shelly
+  ansible.builtin.fail:
+    msg: "'shelly_ip' is required when watchdog_type == 'shelly' (host: {{ inventory_hostname }})."
+  when:
+    - inventory_hostname in groups["engine_servers"]
+    - watchdog_type | default("") == "shelly"
+    - shelly_ip is not defined or shelly_ip | length == 0
+
 - name: Retrieve the list of groups
   ansible.builtin.set_fact:
     group_list:

--- a/roles/check_vars/tasks/main.yml
+++ b/roles/check_vars/tasks/main.yml
@@ -100,14 +100,6 @@
     - watchdog_type | default("") == "pi_zero"
     - pi_zero_hostname is not defined or pi_zero_hostname | length == 0
 
-- name: Check shelly_ip is set when watchdog_type == shelly
-  ansible.builtin.fail:
-    msg: "'shelly_ip' is required when watchdog_type == 'shelly' (host: {{ inventory_hostname }})."
-  when:
-    - inventory_hostname in groups["engine_servers"]
-    - watchdog_type | default("") == "shelly"
-    - shelly_ip is not defined or shelly_ip | length == 0
-
 - name: Retrieve the list of groups
   ansible.builtin.set_fact:
     group_list:

--- a/roles/engine_cron/defaults/main.yml
+++ b/roles/engine_cron/defaults/main.yml
@@ -1,2 +1,8 @@
 ---
 engine_cron_working_dir: "/home/{{ project_name }}"
+
+# Main-pi watchdog script path, by watchdog_type.
+# Follows the pyro-engine watchdog/ layout from PR #374 (zero/ and shelly/).
+watchdog_main_script:
+  pi_zero: "{{ engine_cron_working_dir }}/watchdog/zero/main_pi/watchdog.py"
+  shelly:  "{{ engine_cron_working_dir }}/watchdog/shelly/main_pi/watchdog.py"

--- a/roles/engine_cron/defaults/main.yml
+++ b/roles/engine_cron/defaults/main.yml
@@ -6,3 +6,8 @@ engine_cron_working_dir: "/home/{{ project_name }}"
 watchdog_main_script:
   pi_zero: "{{ engine_cron_working_dir }}/watchdog/zero/main_pi/watchdog.py"
   shelly:  "{{ engine_cron_working_dir }}/watchdog/shelly/main_pi/watchdog.py"
+
+# Shelly watchdog (watchdog_type == "shelly"). The Shelly sits at a fixed LAN
+# address by convention; override per-host only if a station differs.
+shelly_ip: "192.168.1.97"
+shelly_output_id: 0

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
-- name: Create a cronjob to restart the Raspberry Pi every day at midnight
+# Reboot cron (no_watchdog) and watchdog cron (pi_zero/shelly) are mutually
+# exclusive. Each is paired with an explicit removal so changing watchdog_type
+# converges instead of leaving stale jobs behind.
+
+- name: Add nightly reboot cron (no_watchdog)
   ansible.builtin.cron:
     name: "Restart Raspberry Pi"
     minute: "0"
@@ -7,6 +11,13 @@
     job: "/sbin/shutdown -r now"
     user: "root"
   when: watchdog_type == "no_watchdog"
+
+- name: Remove nightly reboot cron when a watchdog is active
+  ansible.builtin.cron:
+    name: "Restart Raspberry Pi"
+    user: "root"
+    state: absent
+  when: watchdog_type in ["pi_zero", "shelly"]
 
 - name: Ensure working directory exists
   ansible.builtin.file:
@@ -32,10 +43,23 @@
     mode: "0644"
   when: watchdog_type == "shelly"
 
-- name: Add cron job for main pi watchdog
+- name: Remove stale main pi watchdog .env file (no_watchdog)
+  ansible.builtin.file:
+    path: /home/pi/watchdog.env
+    state: absent
+  when: watchdog_type == "no_watchdog"
+
+- name: Add cron job for main pi watchdog (pi_zero/shelly)
   ansible.builtin.cron:
     name: "Main pi watchdog"
     minute: "5,15,25,35,45,55"
     job: "/usr/bin/python3 {{ watchdog_main_script[watchdog_type] }} >> /home/pi/watchdog_main.log 2>&1"
     user: pi
   when: watchdog_type in ["pi_zero", "shelly"]
+
+- name: Remove main pi watchdog cron when no_watchdog
+  ansible.builtin.cron:
+    name: "Main pi watchdog"
+    user: pi
+    state: absent
+  when: watchdog_type == "no_watchdog"

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -6,7 +6,7 @@
     hour: "0"
     job: "/sbin/shutdown -r now"
     user: "root"
-  when: pi_zero_hostname is not defined or pi_zero_hostname | length == 0
+  when: watchdog_type == "no_watchdog"
 
 - name: Ensure working directory exists
   ansible.builtin.file:
@@ -14,19 +14,28 @@
     state: directory
     mode: '0755'
 
-- name: Generate main pi watchdog .env file
+- name: Generate main pi watchdog .env file (pi_zero)
   ansible.builtin.template:
     src: watchdog_main.env.j2
     dest: /home/pi/watchdog.env
     owner: pi
     group: pi
     mode: "0644"
-  when: pi_zero_hostname | default("") | length > 0
+  when: watchdog_type == "pi_zero"
+
+- name: Generate main pi watchdog .env file (shelly)
+  ansible.builtin.template:
+    src: watchdog_shelly.env.j2
+    dest: /home/pi/watchdog.env
+    owner: pi
+    group: pi
+    mode: "0644"
+  when: watchdog_type == "shelly"
 
 - name: Add cron job for main pi watchdog
   ansible.builtin.cron:
     name: "Main pi watchdog"
     minute: "5,15,25,35,45,55"
-    job: "/usr/bin/python3 {{ engine_cron_working_dir }}/watchdog/main_pi/watchdog.py >> /home/pi/watchdog_main.log 2>&1"
+    job: "/usr/bin/python3 {{ watchdog_main_script[watchdog_type] }} >> /home/pi/watchdog_main.log 2>&1"
     user: pi
-  when: pi_zero_hostname | default("") | length > 0
+  when: watchdog_type in ["pi_zero", "shelly"]

--- a/roles/engine_cron/templates/watchdog_shelly.env.j2
+++ b/roles/engine_cron/templates/watchdog_shelly.env.j2
@@ -1,0 +1,3 @@
+SHELLY_IP={{ shelly_ip }}
+SHELLY_OUTPUT_ID={{ shelly_output_id | default(0) }}
+CAM_IPS={{ (config_json | from_json).keys() | join(',') }}

--- a/roles/pi_zero_watchdog/defaults/main.yml
+++ b/roles/pi_zero_watchdog/defaults/main.yml
@@ -2,6 +2,6 @@
 pi_zero_repo_url: "https://github.com/pyronear/pyro-engine.git"
 pi_zero_repo_branch: "develop"
 pi_zero_repo_dir: "/home/pi/pyro-engine"
-pi_zero_watchdog_script: "{{ pi_zero_repo_dir }}/watchdog/pi_zero/watchdog.py"
+pi_zero_watchdog_script: "{{ pi_zero_repo_dir }}/watchdog/zero/pi_zero/watchdog.py"
 pi_zero_log_file: "/home/pi/watchdog.log"
 pi_zero_cron_schedule: "*/10 * * * *"


### PR DESCRIPTION

  # Summary

  Replaces the implicit "is pi_zero_hostname set?" logic for choosing a Pi's reboot/watchdog behaviour with an explicit watchdog_type variable. This adds first-class support for the new Shelly watchdog alongside the existing pi-zero watchdog and the plain nightly-reboot fallback, and makes the cron configuration converge cleanly when a host's type changes.

  watchdog_type values

  - no_watchdog — nightly reboot cron (shutdown -r at midnight), no watchdog
  - pi_zero — pi-zero watchdog
  - shelly — Shelly relay watchdog

  # Changes

  - engine_cron
    - Cron jobs are now selected by watchdog_type. Each job is paired with an explicit removal task so switching type (e.g. pi_zero → shelly) tears down the
  stale job/.env instead of leaving it behind.
    - Reboot cron and watchdog cron are mutually exclusive.
    - New watchdog_shelly.env.j2 template (SHELLY_IP, SHELLY_OUTPUT_ID, CAM_IPS derived from config_json).
    - New defaults: watchdog_main_script map (pi_zero/shelly script paths), shelly_ip (default 192.168.1.97), shelly_output_id (default 0).
    - Watchdog script paths updated to the new pyro-engine watchdog/ layout (zero/ and shelly/ subdirs, per pyro-engine PR #374).
  - check_vars
    - Asserts watchdog_type is defined and one of the three valid values on every engine host.
    - Fails fast if watchdog_type == pi_zero but pi_zero_hostname is unset.
  - pi_zero_watchdog
    - pi_zero_watchdog_script path updated to watchdog/zero/pi_zero/watchdog.py.

  # Notes / dependencies

  - Requires the matching pyro-engine watchdog directory layout (watchdog/zero/..., watchdog/shelly/...) to be merged
  - shelly_ip defaults to a fixed LAN address by convention; override per-host for stations that differ.