### PR TITLE
feat: provision sites end-to-end from the site config app

### DIFF
--- a/init_script/common.py
+++ b/init_script/common.py
@@ -7,7 +7,6 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
 
 
 def get_token(api_url: str, login: str, pwd: str) -> str:
-    print(api_url, login, pwd)
     response = requests.post(
         f"{api_url}/api/v1/login/creds",
         data={"username": login, "password": pwd},

--- a/init_script/common.py
+++ b/init_script/common.py
@@ -21,7 +21,7 @@ def get_token(api_url: str, login: str, pwd: str) -> str:
 def api_request(
     method_type: str,
     route: str,
-    headers=Dict[str, str],
+    headers: Dict[str, str],
     payload: Optional[Dict[str, Any]] = None,
 ):
     kwargs = {"json": payload} if isinstance(payload, dict) else {}
@@ -35,9 +35,37 @@ def api_request(
     return response.json()
 
 # Récupérer l'organisation par son nom
-def get_organization_id(api_url: str, superuser_auth: str, org_name: str):
+def get_organization_id(api_url: str, superuser_auth: Dict[str, str], org_name: str):
     response = api_request("get", f"{api_url}/api/v1/organizations/", superuser_auth)
     for orga in response:
         if orga["name"] == org_name:
             return orga["id"]
     raise ValueError(f"Organization '{org_name}' not found.")
+
+
+# Idempotent helpers reused by the Streamlit site generator -------------------
+
+def ensure_organization_id(api_url: str, headers: Dict[str, str], org_name: str):
+    """Return the org id, creating the organization if it does not exist yet."""
+    response = api_request("get", f"{api_url}/api/v1/organizations/", headers)
+    for orga in response:
+        if orga["name"] == org_name:
+            return orga["id"]
+    created = api_request("post", f"{api_url}/api/v1/organizations/", headers, {"name": org_name})
+    return created["id"]
+
+
+def get_cameras(api_url: str, headers: Dict[str, str]):
+    return api_request("get", f"{api_url}/api/v1/cameras/?include_non_trustable=true", headers)
+
+
+def create_camera(api_url: str, headers: Dict[str, str], payload: Dict[str, Any]):
+    return api_request("post", f"{api_url}/api/v1/cameras/", headers, payload)
+
+
+def get_poses(api_url: str, headers: Dict[str, str]):
+    return api_request("get", f"{api_url}/api/v1/poses/", headers)
+
+
+def create_pose(api_url: str, headers: Dict[str, str], payload: Dict[str, Any]):
+    return api_request("post", f"{api_url}/api/v1/poses/", headers, payload)

--- a/site_config/README.md
+++ b/site_config/README.md
@@ -1,19 +1,43 @@
 # Site Config Generator
 
-Streamlit app to generate `host_vars` configuration files for new Pyronear sites.
+Streamlit app that provisions a new Pyronear site end-to-end: it creates the
+organization, cameras and poses in the alert API, then writes the encrypted
+`host_vars/<site>/` folder into the sister repo (`$REPO_PATH`).
 
 ## Usage
 
 ```bash
-uv run --with streamlit streamlit run site_config/app.py
+uv run --with streamlit --with requests --with pandas --with python-dotenv \
+  streamlit run site_config/app.py
 ```
 
 Then open http://localhost:8501 in your browser.
 
-## Features
+It reads `REPO_PATH` and `VAULT_PASSWORD_FILE` from the repo-root `.env`, and
+optionally prefills `API_URL` / superadmin credentials from `init_script/.env`.
 
-- Set site name and number of cameras
-- Choose camera type (PTZ or static)
-- Auto-generated IPs (`192.168.1.11`, `.12`, ...), names, and azimuths
-- Configurable adapter (with custom option), camera ID, number of poses, anonymizer
-- Download the generated `vars` file or raw JSON
+## What "Generate site" does
+
+1. Logs into the API with the superadmin credentials.
+2. Ensures the organization exists (created if missing).
+3. For each camera: creates it (or reuses an existing one with the same name),
+   then creates its poses, capturing the returned `id` and `pose_ids`.
+4. Writes `$REPO_PATH/host_vars/<site>/vars.yml` — `config_json` (with `id` and
+   `pose_ids` embedded), static-IP defaults and `watchdog_type`.
+5. Writes `$REPO_PATH/host_vars/<site>/vars.vault.yml` with the secrets, then
+   runs `ansible-vault encrypt` using `VAULT_PASSWORD_FILE`.
+
+The API step is idempotent: re-running reuses existing cameras/poses by name.
+
+## Fields
+
+- Site name, number of cameras, camera type (PTZ or static), watchdog type
+- API URL + superadmin credentials, organization name
+- Secrets written to the vault file: `ansible_password`, `open_vpn_password`,
+  `CAM_USER`, `CAM_PWD`
+- Per camera: IP, adapter, anonymizer, and the geo data needed to create it in
+  the API (latitude, longitude, elevation, angle of view, trustable, poses)
+
+Static IP (`.99`/`.1`/`eth0`) and the WiFi block default to standard values and
+are not collected in the form — edit `vars.yml` / `vars.vault.yml` afterwards if
+a site needs different ones.

--- a/site_config/README.md
+++ b/site_config/README.md
@@ -32,11 +32,11 @@ The API step is idempotent: re-running reuses existing cameras/poses by name.
 ## Fields
 
 - Site name, number of cameras, camera type (PTZ or static), watchdog type
+- Site coordinates (`lat,lon`), shared by every camera of the site
 - API URL + superadmin credentials, organization name
 - Secrets written to the vault file: `ansible_password`, `open_vpn_password`,
   `CAM_USER`, `CAM_PWD`
-- Per camera: IP, adapter, anonymizer, and the geo data needed to create it in
-  the API (latitude, longitude, elevation, angle of view, trustable, poses)
+- Per camera: IP, adapter, anonymizer, elevation, angle of view, trustable, poses
 
 Static IP (`.99`/`.1`/`eth0`) and the WiFi block default to standard values and
 are not collected in the form — edit `vars.yml` / `vars.vault.yml` afterwards if

--- a/site_config/app.py
+++ b/site_config/app.py
@@ -55,6 +55,12 @@ def compute_azimuths(cam_index: int, num_cams: int, n_poses: int) -> list[int]:
     return [round(step * (start + j)) % 360 for j in range(n_poses)]
 
 
+def parse_coords(text: str) -> tuple[float, float]:
+    """Parse a 'lat,lon' string into floats, raising ValueError if malformed."""
+    lat_str, lon_str = text.split(",")
+    return float(lat_str), float(lon_str)
+
+
 def resolve_vault_password_file() -> Path | None:
     if not VAULT_PASSWORD_FILE:
         return None
@@ -223,17 +229,19 @@ def main():
     with col2:
         num_cams = st.number_input("Number of cameras", min_value=1, max_value=20, value=2)
 
-    c1, c2 = st.columns(2)
+    c1, c2, c3 = st.columns(3)
     with c1:
         cam_type = st.radio("Camera type", ["ptz", "static"], horizontal=True)
     with c2:
         watchdog_type = st.text_input("Watchdog type", value="shelly")
+    with c3:
+        coords = st.text_input("Coordinates (lat,lon)", placeholder="48.1234,2.5678")
 
     # --- API access ---
     st.subheader("API access")
     a1, a2, a3 = st.columns(3)
     with a1:
-        api_url = st.text_input("API URL", value=os.getenv("API_URL", ""))
+        api_url = st.text_input("API URL", value=os.getenv("API_URL", "https://alertapi.pyronear.org/"))
     with a2:
         su_login = st.text_input("Superadmin login", value=os.getenv("SUPERADMIN_LOGIN", ""))
     with a3:
@@ -270,16 +278,12 @@ def main():
         with c3:
             anonymizer = st.checkbox("Anonymizer", value=False, key=f"anon_{i}")
 
-        g1, g2, g3, g4, g5 = st.columns(5)
+        g1, g2, g3 = st.columns(3)
         with g1:
-            lat = st.number_input("Latitude", value=0.0, format="%.6f", key=f"lat_{i}")
+            elevation = st.number_input("Elevation (m)", value=100, key=f"elev_{i}")
         with g2:
-            lon = st.number_input("Longitude", value=0.0, format="%.6f", key=f"lon_{i}")
+            angle_of_view = st.number_input("Angle of view", value=54.2, format="%.1f", key=f"aov_{i}")
         with g3:
-            elevation = st.number_input("Elevation (m)", value=0, key=f"elev_{i}")
-        with g4:
-            angle_of_view = st.number_input("Angle of view", value=87, key=f"aov_{i}")
-        with g5:
             is_trustable = st.checkbox("Trustable", value=True, key=f"trust_{i}")
 
         cam: dict = {
@@ -288,8 +292,6 @@ def main():
             "adapter": adapter,
             "anonymizer": anonymizer,
             "type": cam_type,
-            "lat": lat,
-            "lon": lon,
             "elevation": elevation,
             "angle_of_view": angle_of_view,
             "is_trustable": is_trustable,
@@ -330,6 +332,15 @@ def main():
         if any(not ip for ip in ips) or len(set(ips)) != len(ips):
             st.error("Camera IP addresses must all be set and unique.")
             st.stop()
+
+        try:
+            lat, lon = parse_coords(coords)
+        except ValueError:
+            st.error("Coordinates must be in 'lat,lon' format (e.g. 48.1234,2.5678).")
+            st.stop()
+            return
+        for cam in cameras:
+            cam["lat"], cam["lon"] = lat, lon
 
         form = {
             "site_name": site_name,

--- a/site_config/app.py
+++ b/site_config/app.py
@@ -284,7 +284,7 @@ def main():
         with g2:
             angle_of_view = st.number_input("Angle of view", value=54.2, format="%.1f", key=f"aov_{i}")
         with g3:
-            is_trustable = st.checkbox("Trustable", value=True, key=f"trust_{i}")
+            is_trustable = st.checkbox("Trustable", value=False, key=f"trust_{i}")
 
         cam: dict = {
             "ip": ip,

--- a/site_config/app.py
+++ b/site_config/app.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -192,7 +193,12 @@ def provision_and_write(form: dict) -> Path:
     vault_path.write_text(
         build_vault_yml(form["ansible_password"], form["cam_user"], form["cam_pwd"], form["open_vpn_password"])
     )
-    encrypt_vault_file(vault_path, form["vault_password_file"])
+    try:
+        encrypt_vault_file(vault_path, form["vault_password_file"])
+    except Exception:
+        # Never leave plaintext secrets on disk if encryption fails.
+        vault_path.unlink(missing_ok=True)
+        raise
 
     return dest
 
@@ -314,6 +320,15 @@ def main():
         ]
         if missing:
             st.error("Missing required fields: " + ", ".join(missing))
+            st.stop()
+
+        if not re.fullmatch(r"[a-z0-9-]+", site_name):
+            st.error("Site name must contain only lowercase letters, digits and hyphens.")
+            st.stop()
+
+        ips = [c["ip"] for c in cameras]
+        if any(not ip for ip in ips) or len(set(ips)) != len(ips):
+            st.error("Camera IP addresses must all be set and unique.")
             st.stop()
 
         form = {

--- a/site_config/app.py
+++ b/site_config/app.py
@@ -1,5 +1,32 @@
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import streamlit as st
+from dotenv import load_dotenv
+
+# Make init_script importable so we reuse the API helpers instead of shelling out.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "init_script"))
+
+from common import (  # noqa: E402
+    create_camera,
+    create_pose,
+    ensure_organization_id,
+    get_cameras,
+    get_poses,
+    get_token,
+)
+
+# Repo-level config (REPO_PATH, VAULT_PASSWORD_FILE) lives in the root .env.
+# init_script/.env optionally prefills the API_URL / superadmin fields.
+load_dotenv(REPO_ROOT / ".env", override=True)
+load_dotenv(REPO_ROOT / "init_script" / ".env", override=False)
+
+REPO_PATH = os.getenv("REPO_PATH")
+VAULT_PASSWORD_FILE = os.getenv("VAULT_PASSWORD_FILE")
 
 ADAPTERS = [
     "reolink-823S2",
@@ -11,7 +38,12 @@ ADAPTERS = [
     "url",
 ]
 
-MASK_URL_BASE = "https://occlusion-masks-json.s3.sbg.io.cloud.ovh.net"
+# Static-IP / wifi defaults (not collected in the form, see plan).
+STATIC_IP_INTERFACE = "eth0"
+STATIC_IP_ADDRESS = "192.168.1.99"
+STATIC_IP_GATEWAY = "192.168.1.1"
+DEFAULT_WIFI_SSID = "Pyronear"
+DEFAULT_WIFI_PASSWORD = "@Pyronear"
 
 
 def compute_azimuths(cam_index: int, num_cams: int, n_poses: int) -> list[int]:
@@ -22,18 +54,197 @@ def compute_azimuths(cam_index: int, num_cams: int, n_poses: int) -> list[int]:
     return [round(step * (start + j)) % 360 for j in range(n_poses)]
 
 
+def resolve_vault_password_file() -> Path | None:
+    if not VAULT_PASSWORD_FILE:
+        return None
+    path = Path(VAULT_PASSWORD_FILE)
+    return path if path.is_absolute() else (REPO_ROOT / path)
+
+
+def build_vars_yml(config_dict: dict, watchdog_type: str) -> str:
+    json_str = json.dumps(config_dict, indent=4, ensure_ascii=False)
+    indented = "\n".join("    " + line for line in json_str.splitlines())
+    lines = [
+        f"config_json: |\n{indented}",
+        "",
+        f"static_ip_interface: {STATIC_IP_INTERFACE}",
+        f"static_ip_address: {STATIC_IP_ADDRESS}",
+        f"static_ip_gateway: {STATIC_IP_GATEWAY}",
+    ]
+    if watchdog_type:
+        lines += ["", f"watchdog_type: {watchdog_type}"]
+    return "\n".join(lines) + "\n"
+
+
+def build_vault_yml(ansible_password: str, cam_user: str, cam_pwd: str, openvpn_password: str) -> str:
+    # json.dumps produces a valid double-quoted YAML scalar with proper escaping.
+    return (
+        f"ansible_password: {json.dumps(ansible_password)}\n"
+        'ansible_become_password: "{{ ansible_password }}"\n'
+        "\n"
+        "##### ENGINE\n"
+        f"CAM_USER: {json.dumps(cam_user)}\n"
+        f"CAM_PWD: {json.dumps(cam_pwd)}\n"
+        f"open_vpn_password: {json.dumps(openvpn_password)}\n"
+        "## VPN\n"
+        'openvpn_client_password: "{{ open_vpn_password }}"\n'
+        "\n"
+        "\n"
+        "wifi_connections:\n"
+        f"  - ssid: {json.dumps(DEFAULT_WIFI_SSID)}\n"
+        f"    password: {json.dumps(DEFAULT_WIFI_PASSWORD)}\n"
+        "    priority: 10\n"
+    )
+
+
+def encrypt_vault_file(path: Path, vault_password_file: Path) -> None:
+    subprocess.run(
+        [
+            "ansible-vault",
+            "encrypt",
+            str(path),
+            "--vault-password-file",
+            str(vault_password_file),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def provision_and_write(form: dict) -> Path:
+    """Create org/cameras/poses via the API, then write the host_vars folder."""
+    headers = {
+        "Authorization": f"Bearer {get_token(form['api_url'], form['su_login'], form['su_pwd'])}",
+        "Content-Type": "application/json",
+    }
+    org_id = ensure_organization_id(form["api_url"], headers, form["org_name"])
+
+    existing_cams = get_cameras(form["api_url"], headers)
+    existing_poses = get_poses(form["api_url"], headers)
+
+    config_dict = {}
+    num_cams = len(form["cameras"])
+    for i, cam in enumerate(form["cameras"]):
+        match = next(
+            (c for c in existing_cams if c["organization_id"] == org_id and c["name"] == cam["name"]),
+            None,
+        )
+        if match:
+            cam_id = match["id"]
+        else:
+            created = create_camera(
+                form["api_url"],
+                headers,
+                {
+                    "organization_id": org_id,
+                    "name": cam["name"],
+                    "angle_of_view": cam["angle_of_view"],
+                    "elevation": cam["elevation"],
+                    "lat": cam["lat"],
+                    "lon": cam["lon"],
+                    "is_trustable": cam["is_trustable"],
+                },
+            )
+            cam_id = created["id"]
+
+        ordered: dict = {}
+        if cam["type"] == "ptz":
+            n_poses = cam["n_poses"]
+            azimuths = compute_azimuths(i, num_cams, n_poses)
+            pose_ids = []
+            for patrol_id, azimuth in enumerate(azimuths):
+                existing = next(
+                    (p for p in existing_poses if p["camera_id"] == cam_id and p["patrol_id"] == patrol_id),
+                    None,
+                )
+                if existing:
+                    pose_ids.append(existing["id"])
+                else:
+                    pose = create_pose(
+                        form["api_url"],
+                        headers,
+                        {"camera_id": cam_id, "azimuth": azimuth, "patrol_id": patrol_id},
+                    )
+                    pose_ids.append(pose["id"])
+            ordered["pose_ids"] = pose_ids
+        else:
+            ordered["azimuth"] = cam["azimuth"]
+
+        ordered["adapter"] = cam["adapter"]
+        if cam.get("anonymizer"):
+            ordered["anonymizer"] = True
+        ordered["id"] = str(cam_id)
+        ordered["name"] = cam["name"]
+        ordered["bbox_mask_url"] = ""
+        ordered["poses"] = list(range(cam["n_poses"])) if cam["type"] == "ptz" else []
+        ordered["token"] = ""
+        ordered["type"] = cam["type"]
+        config_dict[cam["ip"]] = ordered
+
+    assert REPO_PATH, "REPO_PATH must be set"
+    dest = Path(REPO_PATH) / "host_vars" / form["site_name"]
+    dest.mkdir(parents=True, exist_ok=True)
+
+    (dest / "vars.yml").write_text(build_vars_yml(config_dict, form["watchdog_type"]))
+
+    vault_path = dest / "vars.vault.yml"
+    vault_path.write_text(
+        build_vault_yml(form["ansible_password"], form["cam_user"], form["cam_pwd"], form["open_vpn_password"])
+    )
+    encrypt_vault_file(vault_path, form["vault_password_file"])
+
+    return dest
+
+
 def main():
     st.set_page_config(page_title="Pyronear Site Config Generator", layout="wide")
     st.title("Pyronear Site Config Generator")
 
+    if not REPO_PATH:
+        st.error("REPO_PATH is not set in the repo-root .env — cannot write host_vars.")
+        st.stop()
+
+    vault_password_file = resolve_vault_password_file()
+    if vault_password_file is None or not vault_password_file.exists():
+        st.error("VAULT_PASSWORD_FILE is not set or missing — cannot encrypt vars.vault.yml.")
+        st.stop()
+
     # --- Site-level settings ---
     col1, col2 = st.columns(2)
     with col1:
-        site_name = st.text_input("Site name", placeholder="germersheim")
+        site_name = st.text_input("Site name", placeholder="sdis-tigery")
     with col2:
         num_cams = st.number_input("Number of cameras", min_value=1, max_value=20, value=2)
 
-    cam_type = st.radio("Camera type", ["ptz", "static"], horizontal=True)
+    c1, c2 = st.columns(2)
+    with c1:
+        cam_type = st.radio("Camera type", ["ptz", "static"], horizontal=True)
+    with c2:
+        watchdog_type = st.text_input("Watchdog type", value="shelly")
+
+    # --- API access ---
+    st.subheader("API access")
+    a1, a2, a3 = st.columns(3)
+    with a1:
+        api_url = st.text_input("API URL", value=os.getenv("API_URL", ""))
+    with a2:
+        su_login = st.text_input("Superadmin login", value=os.getenv("SUPERADMIN_LOGIN", ""))
+    with a3:
+        su_pwd = st.text_input("Superadmin password", value=os.getenv("SUPERADMIN_PWD", ""), type="password")
+    org_name = st.text_input("Organization name", value=site_name)
+
+    # --- Vault secrets ---
+    st.subheader("Secrets (written to vars.vault.yml)")
+    v1, v2, v3, v4 = st.columns(4)
+    with v1:
+        ansible_password = st.text_input("ansible_password", type="password")
+    with v2:
+        open_vpn_password = st.text_input("open_vpn_password", type="password")
+    with v3:
+        cam_user = st.text_input("CAM_USER", value="admin")
+    with v4:
+        cam_pwd = st.text_input("CAM_PWD", value="@Pyronear", type="password")
 
     st.divider()
 
@@ -41,97 +252,95 @@ def main():
     cameras: list[dict] = []
     for i in range(num_cams):
         st.subheader(f"Camera {i + 1}")
-        c1, c2, c3 = st.columns(3)
+        name = f"{site_name}-{i + 1:02d}" if site_name else ""
 
+        c1, c2, c3 = st.columns(3)
         with c1:
             ip = st.text_input("IP address", value=f"192.168.1.{11 + i}", key=f"ip_{i}")
         with c2:
-            cam_id = st.text_input("Camera ID (from API)", value="", key=f"id_{i}")
-        with c3:
             adapter = st.selectbox("Adapter", ADAPTERS + ["Other..."], key=f"adapter_{i}")
             if adapter == "Other...":
                 adapter = st.text_input("Custom adapter", key=f"adapter_custom_{i}")
+        with c3:
+            anonymizer = st.checkbox("Anonymizer", value=False, key=f"anon_{i}")
 
-        name = f"{site_name}-{i + 1:02d}" if site_name else ""
+        g1, g2, g3, g4, g5 = st.columns(5)
+        with g1:
+            lat = st.number_input("Latitude", value=0.0, format="%.6f", key=f"lat_{i}")
+        with g2:
+            lon = st.number_input("Longitude", value=0.0, format="%.6f", key=f"lon_{i}")
+        with g3:
+            elevation = st.number_input("Elevation (m)", value=0, key=f"elev_{i}")
+        with g4:
+            angle_of_view = st.number_input("Angle of view", value=87, key=f"aov_{i}")
+        with g5:
+            is_trustable = st.checkbox("Trustable", value=True, key=f"trust_{i}")
 
-        if cam_type == "ptz":
-            n_poses = st.number_input(
-                "Number of poses", min_value=1, max_value=12, value=4, key=f"nposes_{i}"
-            )
-            azimuths = compute_azimuths(i, num_cams, n_poses)
-            poses = list(range(n_poses))
-        else:
-            azimuth_val = round(i * 360 / num_cams) % 360
-            azimuths = None
-            poses = []
-
-        anonymizer = st.checkbox("Anonymizer", value=False, key=f"anon_{i}")
-
-        cam_data: dict = {
-            "adapter": adapter,
-            "id": cam_id,
+        cam: dict = {
+            "ip": ip,
             "name": name,
-            "bbox_mask_url": f"{MASK_URL_BASE}/{site_name}" if site_name else "",
-            "poses": poses,
-            "token": "",
+            "adapter": adapter,
+            "anonymizer": anonymizer,
             "type": cam_type,
+            "lat": lat,
+            "lon": lon,
+            "elevation": elevation,
+            "angle_of_view": angle_of_view,
+            "is_trustable": is_trustable,
+            "n_poses": 0,
         }
         if cam_type == "ptz":
-            cam_data["azimuths"] = azimuths
+            cam["n_poses"] = st.number_input(
+                "Number of poses", min_value=1, max_value=12, value=4, key=f"nposes_{i}"
+            )
         else:
-            cam_data["azimuth"] = azimuth_val
+            cam["azimuth"] = round(i * 360 / num_cams) % 360
+        cameras.append(cam)
 
-        if anonymizer:
-            cam_data["anonymizer"] = True
-
-        cameras.append((ip, cam_data))
-
-    # --- Generate output ---
     st.divider()
-    st.subheader("Generated `vars` file")
 
-    config_dict = {}
-    for ip, cam_data in cameras:
-        # Build ordered dict to match existing file format
-        ordered = {}
-        if cam_type == "ptz":
-            ordered["azimuths"] = cam_data["azimuths"]
+    if st.button("Generate site", type="primary"):
+        missing = [
+            label
+            for label, value in [
+                ("Site name", site_name),
+                ("API URL", api_url),
+                ("Superadmin login", su_login),
+                ("Superadmin password", su_pwd),
+                ("ansible_password", ansible_password),
+                ("open_vpn_password", open_vpn_password),
+            ]
+            if not value
+        ]
+        if missing:
+            st.error("Missing required fields: " + ", ".join(missing))
+            st.stop()
+
+        form = {
+            "site_name": site_name,
+            "watchdog_type": watchdog_type,
+            "api_url": api_url.rstrip("/"),
+            "su_login": su_login,
+            "su_pwd": su_pwd,
+            "org_name": org_name or site_name,
+            "ansible_password": ansible_password,
+            "open_vpn_password": open_vpn_password,
+            "cam_user": cam_user,
+            "cam_pwd": cam_pwd,
+            "vault_password_file": vault_password_file,
+            "cameras": cameras,
+        }
+
+        try:
+            with st.spinner("Creating org/cameras/poses and writing host_vars..."):
+                dest = provision_and_write(form)
+        except subprocess.CalledProcessError as exc:
+            st.error(f"ansible-vault encrypt failed:\n{exc.stderr or exc.stdout}")
+        except Exception as exc:  # surface API/file errors in the UI
+            st.error(f"Generation failed: {exc}")
         else:
-            ordered["azimuth"] = cam_data["azimuth"]
-        ordered["adapter"] = cam_data["adapter"]
-        if cam_data.get("anonymizer"):
-            ordered["anonymizer"] = True
-        ordered["id"] = cam_data["id"]
-        ordered["name"] = cam_data["name"]
-        ordered["bbox_mask_url"] = cam_data["bbox_mask_url"]
-        ordered["poses"] = cam_data["poses"]
-        ordered["token"] = cam_data["token"]
-        ordered["type"] = cam_data["type"]
-        config_dict[ip] = ordered
-
-    json_str = json.dumps(config_dict, indent=4, ensure_ascii=False)
-    # Indent each line by 4 spaces for YAML block scalar
-    indented = "\n".join("    " + line for line in json_str.splitlines())
-    output = f"config_json: |\n{indented}\n"
-
-    st.code(output, language="yaml")
-
-    if site_name:
-        dl1, dl2 = st.columns(2)
-        with dl1:
-            st.download_button(
-                "Download vars file",
-                data=output,
-                file_name="vars",
-                mime="text/plain",
-            )
-        with dl2:
-            st.download_button(
-                "Download JSON",
-                data=json_str,
-                file_name=f"{site_name}.json",
-                mime="application/json",
-            )
+            st.success(f"Site written to {dest}")
+            st.code((dest / "vars.yml").read_text(), language="yaml")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Extends the Streamlit `site_config` app to provision a new site in one click: creates the org, cameras and poses in the alert API (reusing `init_script/common.py` helpers), then writes `$REPO_PATH/host_vars/<site>/`.
- `vars.yml` embeds the returned camera `id` and `pose_ids` in `config_json`, plus static-IP defaults and `watchdog_type`; `vars.vault.yml` holds the secrets and is encrypted via `ansible-vault` using `VAULT_PASSWORD_FILE`.
- API step is idempotent (reuses cameras/poses by name); inputs are validated and the plaintext vault is removed if encryption fails.
- Adds idempotent API helpers and fixes header type hints / a leaked-password debug print in `common.py`.