### PR TITLE
feat: add preprod alert API deploy target

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -57,6 +57,9 @@ install-platform-react-server: prepare
 install-alert-api-server: prepare
 	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l alert_server
 
+install-alert-api-preprod-server: prepare
+	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l alert_server_preprod
+
 install-temporal-server: prepare
 	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l temporal_server
 

--- a/inventory/inventory.template
+++ b/inventory/inventory.template
@@ -7,6 +7,16 @@ all:
     alert_server:
       hosts:
 
+    alert_server_preprod:
+      hosts:
+
+    # Parent group: shared alert API config lives in group_vars/alert_api_servers.
+    # Deploy plays target this group so prod and preprod stay identical.
+    alert_api_servers:
+      children:
+        alert_server:
+        alert_server_preprod:
+
     platform_py_server:
       hosts:
 

--- a/playbooks/deploy-servers.yml
+++ b/playbooks/deploy-servers.yml
@@ -16,7 +16,7 @@
     - check_vars
 
 - name: Upgrade, install git and docker
-  hosts: alert_server:platform_py_server:platform_react_server:openvpn:mediamtx_server:temporal_server
+  hosts: alert_api_servers:platform_py_server:platform_react_server:openvpn:mediamtx_server:temporal_server
   become: true
   roles:
     - common
@@ -41,7 +41,7 @@
     - servers
 
 - name: Add VPN client
-  hosts: platform_py_server:alert_server
+  hosts: platform_py_server:alert_api_servers
   become: true
   serial: 1
   tasks:
@@ -68,7 +68,7 @@
         - app
 
 - name: Deploy service alert_api
-  hosts: alert_server
+  hosts: alert_api_servers
   become: true
   roles:
     - role: alert_api


### PR DESCRIPTION
- Add `make install-alert-api-preprod-server` to deploy a second, identical alert API for preprod.
- Introduce an `alert_api_servers` parent group (children `alert_server` + `alert_server_preprod`) and point the three alert-API deploy plays at it, so preprod inherits the shared `group_vars` and gets the same deployment as prod.
- Document both leaf groups and the parent in `inventory.template`.

Inventory host, `group_vars/alert_api_servers` (renamed from `alert_server`), and the preprod `host_vars` secrets live in the sister `pi-manager-X` repo.