### PR TITLE
fix: fresh-install deploy bugs (traefik.toml path, openvpn iptable_nat)

### DIFF
--- a/playbooks/deploy-servers.yml
+++ b/playbooks/deploy-servers.yml
@@ -25,6 +25,16 @@
 - name: Deploy Openvpn
   hosts: openvpn
   become: true
+  pre_tasks:
+    - name: Load iptable_nat now (the openvpn container needs the NAT table)
+      community.general.modprobe:
+        name: iptable_nat
+        state: present
+    - name: Ensure iptable_nat is loaded on every boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/iptable_nat.conf
+        content: "iptable_nat\n"
+        mode: "0644"
   roles:
     - pyronear.openvpn
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -12,6 +12,7 @@ collections:
   - name: grafana.grafana
     version: 5.7.0
   - name: community.docker
+  - name: community.general
   - name: amazon.aws
   - name: community.crypto
   - name: ansible.posix

--- a/roles/alert_api/tasks/main.yml
+++ b/roles/alert_api/tasks/main.yml
@@ -27,10 +27,10 @@
     force: false
     mode: 0600 # required by traefik
 
-- name: Create static dynamic conf file for traefik
+- name: Create static and dynamic conf files for traefik
   ansible.builtin.template:
     src: "{{ item }}.j2"
-    dest: "{{ alert_api_working_dir_traefik }}/dynamic_assets.toml"
+    dest: "{{ alert_api_working_dir_traefik }}/{{ item }}"
     mode: 0600
   with_items:
     - "traefik.toml"

--- a/roles/alert_api/tasks/main.yml
+++ b/roles/alert_api/tasks/main.yml
@@ -27,6 +27,17 @@
     force: false
     mode: 0600 # required by traefik
 
+- name: Check whether traefik.toml was left as a directory by a broken deploy
+  ansible.builtin.stat:
+    path: "{{ alert_api_working_dir_traefik }}/traefik.toml"
+  register: traefik_toml_stat
+
+- name: Remove stale traefik.toml directory so the template can create the file
+  ansible.builtin.file:
+    path: "{{ alert_api_working_dir_traefik }}/traefik.toml"
+    state: absent
+  when: traefik_toml_stat.stat.isdir | default(false)
+
 - name: Create static and dynamic conf files for traefik
   ansible.builtin.template:
     src: "{{ item }}.j2"


### PR DESCRIPTION
Two fresh-install bugs surfaced by deploying all services to clean test VMs after the Docker-only refactor. Both break a first-time deploy but are masked on existing prod servers that already have the state. Neither is a refactor regression.

## alert_api: traefik.toml never written
`roles/alert_api/tasks/main.yml` looped over `traefik.toml` and `dynamic_assets.toml` but hardcoded `dest` to `dynamic_assets.toml`, so `traefik.toml` was never created. Docker then auto-created `/home/traefik/traefik.toml` as a **directory**, and traefik crash-looped (`read /etc/traefik/traefik.toml: is a directory`). Fixed `dest` to `{{ alert_api_working_dir_traefik }}/{{ item }}`, and added a stat+remove step so hosts already stuck with the stale directory self-heal (otherwise `template` writes inside the directory and it stays broken).

Verified on a clean VM (file created, traefik healthy) and on a host artificially left with the stale directory (removed and replaced with the file).

## openvpn: NAT kernel module not loaded
The `kylemanna/openvpn` container needs the `iptable_nat` table, but nothing loads the module. On a fresh host the container crash-loops (`can't initialize iptables table 'nat'`). Added a `pre_tasks` block to the "Deploy Openvpn" play that loads `iptable_nat` now and persists it via `/etc/modules-load.d`. Also added `community.general` to `requirements.yml` (it provides the `modprobe` module and was only present transitively; left unversioned to match the other collections here).

Verified after a real reboot: `iptable_nat` auto-loads and the openvpn container comes back up on its own.