### PR TITLE
feat: expose mediamtx WebRTC through the shared traefik

### DIFF
--- a/playbooks/deploy-combined.yml
+++ b/playbooks/deploy-combined.yml
@@ -17,6 +17,11 @@
 - name: Deploy alert API, platform and mediamtx on a single server
   hosts: combined_server
   become: true
+  pre_tasks:
+    - name: Register engine stream paths for mediamtx
+      ansible.builtin.set_fact:
+        mediamtx_paths: "{{ mediamtx_paths | default([]) + [{'name': item}] }}"
+      loop: "{{ groups['engine_servers'] | default([]) }}"
   roles:
     - common
     - docker

--- a/roles/mediamtx/defaults/main.yml
+++ b/roles/mediamtx/defaults/main.yml
@@ -4,3 +4,8 @@ mediamtx_config_file: "{{ mediamtx_config_path }}/mediamtx.yml"
 mediamtx_image: bluenviron/mediamtx
 mediamtx_users: [] # utiliser le json qui est dans la plateforme ?
 mediamtx_paths: []
+# Set to a DNS name to expose WebRTC over HTTPS through the co-hosted shared
+# traefik (requires the traefik role on the same host)
+mediamtx_livestream_hostname: ''
+# Must match the traefik role defaults (shared reverse proxy)
+traefik_dynamic_dir: "{{ traefik_working_dir | default('/home/traefik') }}/dynamic"

--- a/roles/mediamtx/tasks/main.yml
+++ b/roles/mediamtx/tasks/main.yml
@@ -21,3 +21,12 @@
     volumes:
       - "{{ mediamtx_config_file }}:/mediamtx.yml:ro"
     command: "/mediamtx.yml"
+
+# When co-hosted with the shared traefik role, publish an HTTPS route for the
+# WebRTC endpoint (TLS terminated by traefik, proxied to mediamtx on 8889)
+- name: Publish livestream route to the shared traefik dynamic conf directory
+  ansible.builtin.template:
+    src: livestream.toml.j2
+    dest: "{{ traefik_dynamic_dir }}/mediamtx_livestream.toml"
+    mode: 0600
+  when: mediamtx_livestream_hostname is defined and mediamtx_livestream_hostname

--- a/roles/mediamtx/templates/livestream.toml.j2
+++ b/roles/mediamtx/templates/livestream.toml.j2
@@ -1,0 +1,11 @@
+[http.routers.livestream]
+rule = "Host(`{{ mediamtx_livestream_hostname }}`)"
+service = "livestream"
+entryPoints = ["websecure"]
+tls.certResolver = "pyroresolver"
+
+[http.services.livestream]
+  [http.services.livestream.loadBalancer]
+    [[http.services.livestream.loadBalancer.servers]]
+      # mediamtx runs with host networking; reach it through the host's address
+      url = "http://{{ mediamtx_livestream_backend | default(ansible_default_ipv4.address) }}:8889"


### PR DESCRIPTION
- Optional `mediamtx_livestream_hostname` var: when set (and co-hosted with the shared traefik role), the mediamtx role drops a dynamic-conf route terminating TLS at traefik and proxying to the host-network WebRTC endpoint on 8889 — same shape as the existing standalone livestream setup.
- `deploy-combined.yml` now registers one mediamtx path per engine, mirroring `update_conf.yml`, so streams work on a combined VM out of the box.