### PR TITLE
feat: add update-reverse-ssh playbook and key restriction option

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: require-container help ansible-up ansible-stop ping check-engines \
 	init-one-engine deploy-one-engine deploy-all-engines down up \
-	install-openvpn install-mediamtx update-mediamtx-conf install-annotation-server \
+	install-openvpn install-mediamtx update-mediamtx-conf update-reverse-ssh install-annotation-server \
 	install-platform-react-server install-alert-api-server install-temporal-server \
 	install-combined-server init-pi-zero sync-ssh-keys
 
@@ -73,6 +73,9 @@ install-mediamtx: require-container
 
 update-mediamtx-conf: require-container
 	ansible-playbook playbooks/update-mediamtx.yml -i inventory/hosts_prod -l mediamtx_server
+
+update-reverse-ssh: require-container
+	ansible-playbook playbooks/update-reverse-ssh.yml -i inventory/hosts_prod -l $(or $(LIMIT_HOSTS),engine_servers)
 
 install-annotation-server: require-container
 	ansible-playbook playbooks/deploy-servers.yml -i inventory/hosts_prod -l annotation_server

--- a/playbooks/update-reverse-ssh.yml
+++ b/playbooks/update-reverse-ssh.yml
@@ -1,0 +1,8 @@
+---
+# Re-point engine reverse-ssh tunnels at the current reverse_ssh_server
+# (e.g. after moving it to another VM) without a full rpi-init run.
+- name: Update reverse SSH tunnels on engines
+  hosts: engine_servers
+  become: true
+  roles:
+    - reverse_ssh

--- a/roles/reverse_ssh/tasks/main.yml
+++ b/roles/reverse_ssh/tasks/main.yml
@@ -32,6 +32,8 @@
   ansible.posix.authorized_key:
     user: ubuntu
     key: "{{ ssh_pub_key }}"
+    # e.g. "restrict,port-forwarding" to deny shell/exec on shared servers
+    key_options: "{{ reverse_ssh_key_options | default(omit) }}"
   delegate_to: reverse_ssh_server
 
 - name: Create a directory if it does not exist


### PR DESCRIPTION
- `playbooks/update-reverse-ssh.yml` + `make update-reverse-ssh`: re-run only the reverse_ssh role on engines, for when the reverse_ssh_server moves to another VM (full `rpi-init.yml` is overkill for that).
- `reverse_ssh_key_options` (optional, default unchanged): passed to `authorized_key` so a shared server (e.g. a combined VM also hosting the API) can restrict engine keys to `restrict,port-forwarding` — no shell/exec.