### PR TITLE
fix: serialize authorized_key writes to the reverse-ssh server

### DIFF
--- a/roles/reverse_ssh/tasks/main.yml
+++ b/roles/reverse_ssh/tasks/main.yml
@@ -35,6 +35,9 @@
     # e.g. "restrict,port-forwarding" to deny shell/exec on shared servers
     key_options: "{{ reverse_ssh_key_options | default(omit) }}"
   delegate_to: reverse_ssh_server
+  # concurrent writes to the same authorized_keys silently lose keys when
+  # several engines run this in parallel — serialize the delegated task
+  throttle: 1
 
 - name: Create a directory if it does not exist
   ansible.builtin.file:


### PR DESCRIPTION
Running the reverse_ssh role on many engines in parallel races on the delegated server's authorized_keys (read-modify-write, no lock): with 11 engines and 5 forks, 2 keys were silently lost. `throttle: 1` on the delegated task serializes it; the rest of the role stays parallel.