### PR TITLE
feat: allow per-service updates on the combined server

### DIFF
--- a/bin/common/Makefile
+++ b/bin/common/Makefile
@@ -30,6 +30,8 @@ help:
 	@echo "  make install-annotation-server | install-platform-react-server"
 	@echo "  make install-alert-api-server | install-temporal-server"
 	@echo "  make install-combined-server   (traefik + mediamtx + platform + alert API on one VM)"
+	@echo "  make update-combined-api | update-combined-platform | update-combined-mediamtx | update-combined-traefik"
+	@echo "                                 (redeploy a single service on the combined server)"
 
 ansible-up:
 	@if [ -n "$$(git status --porcelain)" ]; then \
@@ -91,6 +93,18 @@ install-temporal-server: require-container
 
 install-combined-server: require-container
 	ansible-playbook playbooks/deploy-combined.yml -i inventory/hosts_prod -l combined_server
+
+update-combined-api: require-container
+	ansible-playbook playbooks/deploy-combined.yml -i inventory/hosts_prod -l combined_server --tags alert_api
+
+update-combined-platform: require-container
+	ansible-playbook playbooks/deploy-combined.yml -i inventory/hosts_prod -l combined_server --tags platform
+
+update-combined-mediamtx: require-container
+	ansible-playbook playbooks/deploy-combined.yml -i inventory/hosts_prod -l combined_server --tags mediamtx
+
+update-combined-traefik: require-container
+	ansible-playbook playbooks/deploy-combined.yml -i inventory/hosts_prod -l combined_server --tags traefik
 
 init-pi-zero: require-container
 	ansible-playbook playbooks/rpi-init-pi-zero.yml -i inventory/hosts_prod -l $(SITE)

--- a/playbooks/deploy-combined.yml
+++ b/playbooks/deploy-combined.yml
@@ -8,6 +8,7 @@
         that:
           - ansible_version.minor | int >= 17
         fail_msg: "Ansible version must be 2.17 or higher."
+      tags: always
 
 # All services on a single VM behind one shared Traefik. The VM can also act
 # as the reverse_ssh_server (nothing to deploy: engines only need sshd and the
@@ -22,10 +23,17 @@
       ansible.builtin.set_fact:
         mediamtx_paths: "{{ mediamtx_paths | default([]) + [{'name': item}] }}"
       loop: "{{ groups['engine_servers'] | default([]) }}"
+      tags: always
   roles:
-    - common
-    - docker
-    - traefik
-    - mediamtx
-    - platform_react
-    - alert_api
+    - role: common
+      tags: common
+    - role: docker
+      tags: docker
+    - role: traefik
+      tags: traefik
+    - role: mediamtx
+      tags: mediamtx
+    - role: platform_react
+      tags: platform
+    - role: alert_api
+      tags: alert_api


### PR DESCRIPTION
- `install-combined-server` redeploys all 6 roles; shipping an API update required restarting mediamtx and the platform too.
- Tag each role in `deploy-combined.yml` so a single service can be targeted with `--tags`; the version check and mediamtx stream-path pre_task are tagged `always`.
- Add `update-combined-api` / `update-combined-platform` / `update-combined-mediamtx` / `update-combined-traefik` Makefile targets.