### PR TITLE
feat: add shelly watchdog support for engines

### DIFF
--- a/docs/howto/watchdog-setup.md
+++ b/docs/howto/watchdog-setup.md
@@ -1,7 +1,13 @@
 # Watchdog Setup
 
-Two watchdog scripts monitor hardware health and power-cycle relays on failure.
-Both are managed by Ansible and read their configuration from a `.env` file generated on the device.
+Watchdog scripts monitor hardware health and power-cycle relays on failure.
+All are managed by Ansible and read their configuration from a `.env` file generated on the device.
+
+A site uses **one** of two variants (set exactly one of `pi_zero_hostname` / `shelly_enabled`):
+- **Pi Zero pairing** — the engine and a Pi Zero watchdog each other through power relays.
+- **Shelly pairing** — a Shelly Pro smart relay watches the engine, and the engine asks the Shelly to power-cycle the cameras/router.
+
+All watchdog scripts live in the [pyro-engine](https://github.com/pyronear/pyro-engine) repo (`watchdog/`), which requires `pyro_engine_git_ref` >= `v1.0.12`.
 
 ---
 
@@ -9,10 +15,12 @@ Both are managed by Ansible and read their configuration from a `.env` file gene
 
 | Script | Runs on | Monitors | Cron schedule |
 |--------|---------|----------|---------------|
-| `watchdog/main_pi/watchdog.py` | Engine (`/home/pyro-engine/`) | Pi Zero reachability | `5,15,25,35,45,55 * * * *` |
-| `watchdog/pi_zero/watchdog.py` | Pi Zero | Engine health + camera pings | `*/10 * * * *` |
+| `watchdog/zero/main_pi/watchdog.py` | Engine (`/home/pyro-engine/`) | Pi Zero reachability | `5,15,25,35,45,55 * * * *` |
+| `watchdog/zero/pi_zero/watchdog.py` | Pi Zero | Engine health + camera pings | `*/10 * * * *` |
+| `watchdog/shelly/main_pi/watchdog.py` | Engine (`/home/pyro-engine/`) | Internet + camera pings | `5,15,25,35,45,55 * * * *` |
+| `watchdog.js` (Shelly script) | Shelly device | Engine health endpoint | every 10 min |
 
-The two schedules are offset by 5 minutes so they never run simultaneously.
+The paired schedules are offset by 5 minutes so they never run simultaneously.
 
 ---
 
@@ -45,6 +53,43 @@ Deployed by the `pi_zero_watchdog` role, called from `rpi-init-pi-zero.yml`.
 
 `MAIN_PI_IP` is derived from `hostvars[relay_host]['static_ip_address']`.
 `CAM_IPS` is derived from the keys of `hostvars[relay_host]['config_json']`.
+
+---
+
+## Shelly watchdog
+
+For sites where the engine is paired with a Shelly Pro relay instead of a Pi Zero.
+Deployed by the `shelly_watchdog` role, called from `deploy-engines.yml`.
+
+Only runs if `shelly_enabled: true` is set in the engine's host_vars (mutually
+exclusive with `pi_zero_hostname`).
+
+The role manages both sides:
+
+- **Engine side** — writes `/home/pi/watchdog.env` (`SHELLY_IP`, `SHELLY_OUTPUT_ID`,
+  `CAM_IPS` from the keys of the host's `config_json`) and a cron entry for
+  `watchdog/shelly/main_pi/watchdog.py`, which checks internet + cameras and asks
+  the Shelly to power-cycle output 0 on repeated failures.
+- **Shelly side** — from the engine (which shares the Shelly's LAN), runs the
+  upstream `harden_shelly.sh` (disables cloud/MQTT/BLE/AP, forces outputs on at
+  boot) and uploads `watchdog.js` with `PI_URL` patched to the engine's
+  `http://<static_ip_address>:8081/health` endpoint. The Shelly then reboots the
+  engine's power if the health endpoint fails repeatedly. The play verifies the
+  script reports `running: true` at the end.
+
+The upload is skipped when the patched `watchdog.js` is unchanged and the script
+is already running, so a routine re-deploy does not reset the Shelly's reboot budget.
+
+| Variable | Where | Description |
+|----------|-------|-------------|
+| `shelly_enabled` | `host_vars/<engine>/vars.yml` | Set to `true` to deploy the Shelly watchdog |
+| `shelly_watchdog_ip` | role default | Shelly's fixed LAN IP (`192.168.1.97`, same on every site) |
+| `shelly_watchdog_output_id` | role default | Shelly output power-cycled by the engine (`0`) |
+
+**Prerequisite (manual, once per device):** put the Shelly on the site's Wi-Fi at
+its fixed IP with the Shelly Smart Control app (Bluetooth onboarding). See
+`watchdog/shelly/device/README.md` in pyro-engine. Make sure the Shelly is not
+powered by one of the outputs it cuts.
 
 ---
 

--- a/playbooks/deploy-engines.yml
+++ b/playbooks/deploy-engines.yml
@@ -19,3 +19,5 @@
   roles:
     - engine
     - engine_cron # needs to be laucnhed after the engine's installation
+    - role: shelly_watchdog # engines paired with a Shelly relay instead of a Pi Zero
+      when: shelly_enabled | default(false) | bool

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -27,6 +27,6 @@
   ansible.builtin.cron:
     name: "Main pi watchdog"
     minute: "5,15,25,35,45,55"
-    job: "/usr/bin/python3 {{ engine_cron_working_dir }}/watchdog/main_pi/watchdog.py >> /home/pi/watchdog_main.log 2>&1"
+    job: "/usr/bin/python3 {{ engine_cron_working_dir }}/watchdog/zero/main_pi/watchdog.py >> /home/pi/watchdog_main.log 2>&1"
     user: pi
   when: pi_zero_hostname | default("") | length > 0

--- a/roles/engine_cron/tasks/main.yml
+++ b/roles/engine_cron/tasks/main.yml
@@ -14,6 +14,21 @@
     state: directory
     mode: '0755'
 
+- name: Check that the pyro-engine checkout ships the Pi Zero watchdog
+  ansible.builtin.stat:
+    path: "{{ engine_cron_working_dir }}/watchdog/zero/main_pi/watchdog.py"
+  register: engine_cron_watchdog_script
+  when: pi_zero_hostname | default("") | length > 0
+
+- name: Assert the Pi Zero watchdog script is present
+  ansible.builtin.assert:
+    that:
+      - engine_cron_watchdog_script.stat.exists
+    fail_msg: >-
+      watchdog/zero not found in {{ engine_cron_working_dir }} —
+      pyro_engine_git_ref must be v1.0.12 or later.
+  when: pi_zero_hostname | default("") | length > 0
+
 - name: Generate main pi watchdog .env file
   ansible.builtin.template:
     src: watchdog_main.env.j2

--- a/roles/pi_zero_watchdog/defaults/main.yml
+++ b/roles/pi_zero_watchdog/defaults/main.yml
@@ -2,6 +2,6 @@
 pi_zero_repo_url: "https://github.com/pyronear/pyro-engine.git"
 pi_zero_repo_branch: "develop"
 pi_zero_repo_dir: "/home/pi/pyro-engine"
-pi_zero_watchdog_script: "{{ pi_zero_repo_dir }}/watchdog/pi_zero/watchdog.py"
+pi_zero_watchdog_script: "{{ pi_zero_repo_dir }}/watchdog/zero/pi_zero/watchdog.py"
 pi_zero_log_file: "/home/pi/watchdog.log"
 pi_zero_cron_schedule: "*/10 * * * *"

--- a/roles/shelly_watchdog/defaults/main.yml
+++ b/roles/shelly_watchdog/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+shelly_watchdog_ip: "192.168.1.97"
+shelly_watchdog_output_id: 0
+shelly_watchdog_script_name: "pi_watchdog"
+shelly_watchdog_repo_dir: "/home/{{ project_name }}"
+shelly_watchdog_device_dir: "{{ shelly_watchdog_repo_dir }}/watchdog/shelly/device"
+shelly_watchdog_work_dir: "/home/pi/.shelly_watchdog"
+shelly_watchdog_health_url: "http://{{ static_ip_address }}:8081/health"

--- a/roles/shelly_watchdog/tasks/main.yml
+++ b/roles/shelly_watchdog/tasks/main.yml
@@ -1,0 +1,116 @@
+---
+- name: Check Shelly watchdog prerequisites
+  ansible.builtin.assert:
+    that:
+      - pi_zero_hostname is not defined or pi_zero_hostname | length == 0
+      - static_ip_address is defined
+      - static_ip_address | length > 0
+      - config_json is defined
+    fail_msg: >-
+      Shelly hosts need static_ip_address and config_json in host_vars,
+      and must not set pi_zero_hostname (the two watchdog variants are exclusive).
+
+- name: Check that the pyro-engine checkout ships the Shelly watchdog
+  ansible.builtin.stat:
+    path: "{{ shelly_watchdog_device_dir }}/setup_shelly_watchdog.sh"
+  register: shelly_watchdog_setup_script
+
+- name: Assert the Shelly watchdog scripts are present
+  ansible.builtin.assert:
+    that:
+      - shelly_watchdog_setup_script.stat.exists
+    fail_msg: >-
+      watchdog/shelly not found in {{ shelly_watchdog_repo_dir }} —
+      pyro_engine_git_ref must be v1.0.12 or later.
+
+- name: Generate main pi watchdog .env file
+  ansible.builtin.template:
+    src: watchdog.env.j2
+    dest: /home/pi/watchdog.env
+    owner: pi
+    group: pi
+    mode: "0644"
+
+- name: Add cron job for main pi watchdog
+  ansible.builtin.cron:
+    name: "Main pi watchdog"
+    minute: "5,15,25,35,45,55"
+    job: "/usr/bin/python3 {{ shelly_watchdog_repo_dir }}/watchdog/shelly/main_pi/watchdog.py >> /home/pi/watchdog_main.log 2>&1"
+    user: pi
+
+- name: Ensure Shelly watchdog work directory exists
+  ansible.builtin.file:
+    path: "{{ shelly_watchdog_work_dir }}"
+    state: directory
+    owner: pi
+    group: pi
+    mode: "0755"
+
+- name: Read watchdog.js from the pyro-engine checkout
+  ansible.builtin.slurp:
+    src: "{{ shelly_watchdog_device_dir }}/watchdog.js"
+  register: shelly_watchdog_js_src
+
+- name: Assert watchdog.js still declares PI_URL
+  ansible.builtin.assert:
+    that:
+      - shelly_watchdog_js_src.content | b64decode is search('let PI_URL = ')
+    fail_msg: >-
+      PI_URL declaration not found in watchdog.js — the upstream layout
+      changed, update this role before deploying.
+
+- name: Write watchdog.js patched with this host's health URL
+  ansible.builtin.copy:
+    content: >-
+      {{ shelly_watchdog_js_src.content | b64decode
+         | regex_replace('let PI_URL = .*;', 'let PI_URL = "' ~ shelly_watchdog_health_url ~ '";') }}
+    dest: "{{ shelly_watchdog_work_dir }}/watchdog.js"
+    owner: pi
+    group: pi
+    mode: "0644"
+  register: shelly_watchdog_js
+
+- name: Harden the Shelly device configuration
+  ansible.builtin.command:
+    cmd: bash {{ shelly_watchdog_device_dir }}/harden_shelly.sh
+    chdir: "{{ shelly_watchdog_work_dir }}"
+  environment:
+    SHELLY_IP: "{{ shelly_watchdog_ip }}"
+    OUT_DIR: "{{ shelly_watchdog_work_dir }}"
+  changed_when: false
+
+- name: Query Shelly script list
+  ansible.builtin.uri:
+    url: "http://{{ shelly_watchdog_ip }}/rpc/Script.List"
+    return_content: true
+  register: shelly_watchdog_scripts
+
+- name: Determine whether the watchdog script is installed and running
+  ansible.builtin.set_fact:
+    shelly_watchdog_running: >-
+      {{ shelly_watchdog_scripts.json.scripts | default([])
+         | selectattr('name', 'equalto', shelly_watchdog_script_name)
+         | selectattr('running', 'defined') | selectattr('running')
+         | list | length > 0 }}
+
+- name: Install and start the Shelly watchdog script
+  ansible.builtin.command:
+    cmd: bash {{ shelly_watchdog_device_dir }}/setup_shelly_watchdog.sh
+    chdir: "{{ shelly_watchdog_work_dir }}"
+  environment:
+    SHELLY_IP: "{{ shelly_watchdog_ip }}"
+    SCRIPT_NAME: "{{ shelly_watchdog_script_name }}"
+    SCRIPT_FILE: "{{ shelly_watchdog_work_dir }}/watchdog.js"
+  when: shelly_watchdog_js is changed or not (shelly_watchdog_running | bool)
+  changed_when: true
+
+- name: Verify the Shelly watchdog script is running
+  ansible.builtin.uri:
+    url: "http://{{ shelly_watchdog_ip }}/rpc/Script.List"
+    return_content: true
+  register: shelly_watchdog_scripts_after
+  failed_when: >-
+    shelly_watchdog_scripts_after.json.scripts | default([])
+    | selectattr('name', 'equalto', shelly_watchdog_script_name)
+    | selectattr('running', 'defined') | selectattr('running')
+    | list | length == 0

--- a/roles/shelly_watchdog/templates/watchdog.env.j2
+++ b/roles/shelly_watchdog/templates/watchdog.env.j2
@@ -1,0 +1,3 @@
+SHELLY_IP={{ shelly_watchdog_ip }}
+SHELLY_OUTPUT_ID={{ shelly_watchdog_output_id }}
+CAM_IPS={{ (config_json | from_json).keys() | join(',') }}


### PR DESCRIPTION
- Some engines are paired with a Shelly Pro relay instead of a Pi Zero; its watchdog setup was fully manual.
- New `shelly_watchdog` role (gated on the `shelly_enabled` host_var) deploys the Pi-side env + cron and provisions the Shelly (harden + upload `watchdog.js` with the host's health URL) from the pyro-engine checkout, then verifies the script is running.
- Update watchdog paths for the pyro-engine v1.0.12 layout (`watchdog/zero/...`) and fail the deploy if the checkout is older.
- Requires `pyro_engine_git_ref` >= v1.0.12 in the sister repo's group_vars.